### PR TITLE
Add ONNX connector function calling support

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -59,6 +59,9 @@
     <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.73.1" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.5.1" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntime" Version="1.22.0" />
+    <PackageVersion Include="Microsoft.ML.OnnxRuntime.Gpu.Windows" Version="1.22.1" />
+    <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI" Version="0.8.2" />
+    <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI.Cuda" Version="0.8.1" />
     <PackageVersion Include="Microsoft.ML.Tokenizers.Data.Cl100kBase" Version="1.0.1" />
     <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.58.0" />
     <PackageVersion Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.58.0" />
@@ -204,11 +207,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <!-- OnnxRuntimeGenAI -->
-    <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI" Version="0.8.2" />
-    <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI.Cuda" Version="0.8.1" />
-    <PackageVersion Include="Microsoft.ML.OnnxRuntime.Gpu.Windows" Version="1.22.1" />
-    <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Version="0.8.1" />
     <!-- SpectreConsole-->
     <PackageVersion Include="Spectre.Console" Version="0.49.1" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.49.1" />

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -199,10 +199,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <!-- Serilog -->
-    <PackageVersion Include="Serilog" Version="3.1.1" />
-    <PackageVersion Include="Serilog.Extensions.Logging" Version="8.0.0" />
-    <PackageVersion Include="Serilog.Sinks.Console" Version="5.0.1" />
     <PackageVersion Include="Roslynator.Formatting.Analyzers" Version="[4.13.1]" />
     <PackageReference Include="Roslynator.Formatting.Analyzers">
       <PrivateAssets>all</PrivateAssets>

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -199,6 +199,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <!-- Serilog -->
+    <PackageVersion Include="Serilog" Version="3.1.1" />
+    <PackageVersion Include="Serilog.Extensions.Logging" Version="8.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="5.0.1" />
     <PackageVersion Include="Roslynator.Formatting.Analyzers" Version="[4.13.1]" />
     <PackageReference Include="Roslynator.Formatting.Analyzers">
       <PrivateAssets>all</PrivateAssets>

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -207,6 +207,7 @@
     <!-- OnnxRuntimeGenAI -->
     <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI" Version="0.8.2" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI.Cuda" Version="0.8.1" />
+    <PackageVersion Include="Microsoft.ML.OnnxRuntime.Gpu.Windows" Version="1.22.1" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Version="0.8.1" />
     <!-- SpectreConsole-->
     <PackageVersion Include="Spectre.Console" Version="0.49.1" />

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -119,7 +119,7 @@
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.9.1" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />

--- a/dotnet/SK-dotnet.slnx
+++ b/dotnet/SK-dotnet.slnx
@@ -40,6 +40,7 @@
     <Project Path="samples/Demos/ModelContextProtocolPlugin/ModelContextProtocolPlugin.csproj" />
     <Project Path="samples/Demos/ModelContextProtocolPluginAuth/ModelContextProtocolPluginAuth.csproj" />
     <Project Path="samples/Demos/OllamaFunctionCalling/OllamaFunctionCalling.csproj" />
+    <Project Path="samples/Demos/OnnxFunctionCalling/OnnxFunctionCalling.csproj" />
     <Project Path="samples/Demos/OnnxSimpleRAG/OnnxSimpleRAG.csproj" />
     <Project Path="samples/Demos/OpenAIRealtime/OpenAIRealtime.csproj" />
     <Project Path="samples/Demos/ProcessWithDapr/ProcessWithDapr.csproj" />

--- a/dotnet/SK-dotnet.slnx
+++ b/dotnet/SK-dotnet.slnx
@@ -10,7 +10,7 @@
     <File Path="samples/README.md" />
   </Folder>
   <Folder Name="/samples/Demos/">
-    <Project Path="samples/Demos/AIModelRouter/AIModelRouter.csproj" />
+    <Project Path="AIModelRouter/AIModelRouter.csproj" />
     <Project Path="samples/Demos/AmazonBedrockModels/AmazonBedrockAIModels.csproj" />
     <Project Path="samples/Demos/AotCompatibility/AotCompatibility.csproj" />
     <Project Path="samples/Demos/BookingRestaurant/BookingRestaurant.csproj" />
@@ -31,6 +31,7 @@
     <Project Path="samples/Demos/TelemetryWithAppInsights/TelemetryWithAppInsights.csproj" />
     <Project Path="samples/Demos/TimePlugin/TimePlugin.csproj" />
     <Project Path="samples/Demos/VectorStoreRAG/VectorStoreRAG.csproj" />
+    <Project Path="samples\Demos\OpenAIFunctionCalling\OpenAIFunctionCalling.csproj" Type="Classic C#" />
     <File Path="samples/Demos/README.md" />
   </Folder>
   <Folder Name="/samples/Demos/A2AClientServer/">

--- a/dotnet/SK-dotnet.slnx
+++ b/dotnet/SK-dotnet.slnx
@@ -1,24 +1,5 @@
 <Solution>
-  <Folder Name="/Solution Items/">
-    <File Path="../.editorconfig" />
-    <File Path="../.github/workflows/dotnet-format.yml" />
-    <File Path="../.gitignore" />
-    <File Path="../nuget.config" />
-    <File Path="../README.md" />
-    <File Path="Directory.Build.props" />
-    <File Path="Directory.Build.targets" />
-    <File Path="Directory.Packages.props" />
-    <File Path="docs/EXPERIMENTS.md" />
-    <File Path="global.json" />
-  </Folder>
-  <Folder Name="/Solution Items/nuget/">
-    <File Path="nuget/icon.png" />
-    <File Path="nuget/nuget-package.props" />
-    <File Path="nuget/NUGET.md" />
-    <File Path="nuget/VECTORDATA-CONNECTORS-NUGET.md" />
-  </Folder>
   <Folder Name="/samples/">
-    <File Path="samples/README.md" />
     <Project Path="samples/Concepts/Concepts.csproj" />
     <Project Path="samples/GettingStarted/GettingStarted.csproj" />
     <Project Path="samples/GettingStartedWithAgents/GettingStartedWithAgents.csproj" />
@@ -26,9 +7,9 @@
     <Project Path="samples/GettingStartedWithTextSearch/GettingStartedWithTextSearch.csproj" />
     <Project Path="samples/GettingStartedWithVectorStores/GettingStartedWithVectorStores.csproj" />
     <Project Path="samples/LearnResources/LearnResources.csproj" />
+    <File Path="samples/README.md" />
   </Folder>
   <Folder Name="/samples/Demos/">
-    <File Path="samples/Demos/README.md" />
     <Project Path="samples/Demos/AIModelRouter/AIModelRouter.csproj" />
     <Project Path="samples/Demos/AmazonBedrockModels/AmazonBedrockAIModels.csproj" />
     <Project Path="samples/Demos/AotCompatibility/AotCompatibility.csproj" />
@@ -50,39 +31,58 @@
     <Project Path="samples/Demos/TelemetryWithAppInsights/TelemetryWithAppInsights.csproj" />
     <Project Path="samples/Demos/TimePlugin/TimePlugin.csproj" />
     <Project Path="samples/Demos/VectorStoreRAG/VectorStoreRAG.csproj" />
+    <File Path="samples/Demos/README.md" />
   </Folder>
   <Folder Name="/samples/Demos/A2AClientServer/">
     <Project Path="samples/Demos/A2AClientServer/A2AClient/A2AClient.csproj" />
     <Project Path="samples/Demos/A2AClientServer/A2AServer/A2AServer.csproj" />
   </Folder>
   <Folder Name="/samples/Demos/AgentFrameworkWithAspire/">
-    <File Path="samples/Demos/AgentFrameworkWithAspire/README.md" />
     <Project Path="samples/Demos/AgentFrameworkWithAspire/ChatWithAgent.ApiService/ChatWithAgent.ApiService.csproj" />
     <Project Path="samples/Demos/AgentFrameworkWithAspire/ChatWithAgent.AppHost/ChatWithAgent.AppHost.csproj" />
     <Project Path="samples/Demos/AgentFrameworkWithAspire/ChatWithAgent.Configuration/ChatWithAgent.Configuration.csproj" />
     <Project Path="samples/Demos/AgentFrameworkWithAspire/ChatWithAgent.ServiceDefaults/ChatWithAgent.ServiceDefaults.csproj" />
     <Project Path="samples/Demos/AgentFrameworkWithAspire/ChatWithAgent.Web/ChatWithAgent.Web.csproj" />
+    <File Path="samples/Demos/AgentFrameworkWithAspire/README.md" />
   </Folder>
   <Folder Name="/samples/Demos/ModelContextProtocolClientServer/">
-    <File Path="samples/Demos/ModelContextProtocolClientServer/README.md" />
     <Project Path="samples/Demos/ModelContextProtocolClientServer/MCPClient/MCPClient.csproj">
       <BuildDependency Project="samples/Demos/ModelContextProtocolClientServer/MCPServer/MCPServer.csproj" />
     </Project>
     <Project Path="samples/Demos/ModelContextProtocolClientServer/MCPServer/MCPServer.csproj" />
+    <File Path="samples/Demos/ModelContextProtocolClientServer/README.md" />
   </Folder>
   <Folder Name="/samples/Demos/ProcessFrameworkWithAspire/">
-    <File Path="samples/Demos/ProcessFrameworkWithAspire/README.md" />
     <Project Path="samples/Demos/ProcessFrameworkWithAspire/ProcessFramework.Aspire/ProcessFramework.Aspire.AppHost/ProcessFramework.Aspire.AppHost.csproj" />
     <Project Path="samples/Demos/ProcessFrameworkWithAspire/ProcessFramework.Aspire/ProcessFramework.Aspire.ProcessOrchestrator/ProcessFramework.Aspire.ProcessOrchestrator.csproj" />
     <Project Path="samples/Demos/ProcessFrameworkWithAspire/ProcessFramework.Aspire/ProcessFramework.Aspire.ServiceDefaults/ProcessFramework.Aspire.ServiceDefaults.csproj" />
     <Project Path="samples/Demos/ProcessFrameworkWithAspire/ProcessFramework.Aspire/ProcessFramework.Aspire.Shared/ProcessFramework.Aspire.Shared.csproj" />
     <Project Path="samples/Demos/ProcessFrameworkWithAspire/ProcessFramework.Aspire/ProcessFramework.Aspire.SummaryAgent/ProcessFramework.Aspire.SummaryAgent.csproj" />
     <Project Path="samples/Demos/ProcessFrameworkWithAspire/ProcessFramework.Aspire/ProcessFramework.Aspire.TranslatorAgent/ProcessFramework.Aspire.TranslatorAgent.csproj" />
+    <File Path="samples/Demos/ProcessFrameworkWithAspire/README.md" />
   </Folder>
   <Folder Name="/samples/Demos/ProcessWithCloudEvents/">
-    <File Path="samples/Demos/ProcessWithCloudEvents/README.md" />
     <Project Path="samples/Demos/ProcessWithCloudEvents/ProcessWithCloudEvents.Grpc/ProcessWithCloudEvents.Grpc.csproj" />
     <Project Path="samples/Demos/ProcessWithCloudEvents/ProcessWithCloudEvents.Processes/ProcessWithCloudEvents.Processes.csproj" />
+    <File Path="samples/Demos/ProcessWithCloudEvents/README.md" />
+  </Folder>
+  <Folder Name="/Solution Items/">
+    <File Path="../.editorconfig" />
+    <File Path="../.github/workflows/dotnet-format.yml" />
+    <File Path="../.gitignore" />
+    <File Path="../nuget.config" />
+    <File Path="../README.md" />
+    <File Path="Directory.Build.props" />
+    <File Path="Directory.Build.targets" />
+    <File Path="Directory.Packages.props" />
+    <File Path="docs/EXPERIMENTS.md" />
+    <File Path="global.json" />
+  </Folder>
+  <Folder Name="/Solution Items/nuget/">
+    <File Path="nuget/icon.png" />
+    <File Path="nuget/nuget-package.props" />
+    <File Path="nuget/NUGET.md" />
+    <File Path="nuget/VECTORDATA-CONNECTORS-NUGET.md" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/IntegrationTests/IntegrationTests.csproj" />
@@ -133,24 +133,6 @@
     <Project Path="src/Connectors/Connectors.Onnx/Connectors.Onnx.csproj" />
     <Project Path="src/Connectors/Connectors.OpenAI.UnitTests/Connectors.OpenAI.UnitTests.csproj" />
     <Project Path="src/Connectors/Connectors.OpenAI/Connectors.OpenAI.csproj" />
-  </Folder>
-  <Folder Name="/src/VectorData/">
-    <File Path="src/VectorData/Directory.Build.props" />
-    <Project Path="src/VectorData/AzureAISearch/AzureAISearch.csproj" />
-    <Project Path="src/VectorData/Chroma/Chroma.csproj" />
-    <Project Path="src/VectorData/CosmosMongoDB/CosmosMongoDB.csproj" />
-    <Project Path="src/VectorData/CosmosNoSql/CosmosNoSql.csproj" />
-    <Project Path="src/VectorData/InMemory/InMemory.csproj" />
-    <Project Path="src/VectorData/Milvus/Milvus.csproj" />
-    <Project Path="src/VectorData/MongoDB/MongoDB.csproj" />
-    <Project Path="src/VectorData/PgVector/PgVector.csproj" />
-    <Project Path="src/VectorData/Pinecone/Pinecone.csproj" />
-    <Project Path="src/VectorData/Qdrant/Qdrant.csproj" />
-    <Project Path="src/VectorData/Redis/Redis.csproj" />
-    <Project Path="src/VectorData/SqliteVec/SqliteVec.csproj" />
-    <Project Path="src/VectorData/SqlServer/SqlServer.csproj" />
-    <Project Path="src/VectorData/VectorData.Abstractions/VectorData.Abstractions.csproj" />
-    <Project Path="src/VectorData/Weaviate/Weaviate.csproj" />
   </Folder>
   <Folder Name="/src/experimental/">
     <Project Path="src/Experimental/Orchestration.Flow.IntegrationTests/Experimental.Orchestration.Flow.IntegrationTests.csproj" />
@@ -305,6 +287,24 @@
     <Project Path="src/Plugins/Plugins.UnitTests/Plugins.UnitTests.csproj" />
     <Project Path="src/Plugins/Plugins.Web/Plugins.Web.csproj" />
   </Folder>
+  <Folder Name="/src/VectorData/">
+    <Project Path="src/VectorData/AzureAISearch/AzureAISearch.csproj" />
+    <Project Path="src/VectorData/Chroma/Chroma.csproj" />
+    <Project Path="src/VectorData/CosmosMongoDB/CosmosMongoDB.csproj" />
+    <Project Path="src/VectorData/CosmosNoSql/CosmosNoSql.csproj" />
+    <Project Path="src/VectorData/InMemory/InMemory.csproj" />
+    <Project Path="src/VectorData/Milvus/Milvus.csproj" />
+    <Project Path="src/VectorData/MongoDB/MongoDB.csproj" />
+    <Project Path="src/VectorData/PgVector/PgVector.csproj" />
+    <Project Path="src/VectorData/Pinecone/Pinecone.csproj" />
+    <Project Path="src/VectorData/Qdrant/Qdrant.csproj" />
+    <Project Path="src/VectorData/Redis/Redis.csproj" />
+    <Project Path="src/VectorData/SqliteVec/SqliteVec.csproj" />
+    <Project Path="src/VectorData/SqlServer/SqlServer.csproj" />
+    <Project Path="src/VectorData/VectorData.Abstractions/VectorData.Abstractions.csproj" />
+    <Project Path="src/VectorData/Weaviate/Weaviate.csproj" />
+    <File Path="src/VectorData/Directory.Build.props" />
+  </Folder>
   <Folder Name="/test/" />
   <Folder Name="/test/VectorData/">
     <Project Path="test/VectorData/AzureAISearch.ConformanceTests/AzureAISearch.ConformanceTests.csproj" />
@@ -334,4 +334,5 @@
     <Project Path="test/VectorData/Weaviate.ConformanceTests/Weaviate.ConformanceTests.csproj" />
     <Project Path="test/VectorData/Weaviate.UnitTests/Weaviate.UnitTests.csproj" />
   </Folder>
+  <Project Path="development\development.csproj" Type="Classic C#" />
 </Solution>

--- a/dotnet/development/Program.cs
+++ b/dotnet/development/Program.cs
@@ -1,0 +1,101 @@
+﻿using System.ComponentModel;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.Connectors.Onnx;
+
+var builder = Kernel.CreateBuilder();
+
+// Use the function calling version instead of the basic one
+builder.AddOnnxRuntimeGenAIFunctionCallingChatCompletion(
+    "phi-4-multimodal-instruct",
+    "D:\\VisionCATS_AI_Agent\\Development\\.cache\\models\\microsoft_Phi_4_multimodal_instruct_onnx-gpu_gpu_int4_rtn_block_32",
+    providers: ["cuda"]);
+
+builder.Plugins.AddFromType<DefaultPlugin>();
+
+var kernel = builder.Build();
+
+// Use chat completion service
+var history = new ChatHistory();
+history.AddSystemMessage("""
+                         You are a helpful assistant.
+                         You are not restricted to using the provided plugins,
+                         and you can use information from your training.
+                         Please explain your reasoning with the response.
+                         """);
+
+var chatCompletionService = kernel.GetRequiredService<IChatCompletionService>();
+
+// Enable function calling with auto-invocation
+var executionSettings = new OnnxRuntimeGenAIPromptExecutionSettings
+{
+    ToolCallBehavior = OnnxToolCallBehavior.AutoInvokeKernelFunctions
+};
+
+while (true)
+{
+    Console.Write("User > ");
+    var userMessage = Console.ReadLine();
+    if (userMessage == "exit" || userMessage == "quit")
+    {
+        break;
+    }
+
+    if (string.IsNullOrEmpty(userMessage))
+    {
+        continue;
+    }
+
+    history.AddUserMessage(userMessage);
+
+    try
+    {
+        // Use the non-streaming API for function calling
+        var results = await chatCompletionService.GetChatMessageContentsAsync(history, executionSettings, kernel);
+
+        var fullMessage = "";
+        foreach (var result in results)
+        {
+            Console.Write("Assistant > ");
+            Console.WriteLine(result.Content);
+            fullMessage = result.Content ?? "";
+        }
+
+        history.AddAssistantMessage(fullMessage);
+    }
+    catch (Exception e)
+    {
+        Console.WriteLine($"Error: {e.Message}");
+    }
+}
+
+// No explicit dispose needed; kernel manages service lifetimes
+
+public class DefaultPlugin
+{
+    [KernelFunction]
+    [Description("get the current date and time")]
+    public static DateTime Time()
+    {
+        return DateTime.Now;
+    }
+
+    [KernelFunction]
+    [Description("get the current day of the week")]
+    public static DayOfWeek DayOfWeek()
+    {
+        return DateTime.UtcNow.DayOfWeek;
+    }
+}
+
+// public class LoggingFilter(Serilog.ILogger logger) : IFunctionInvocationFilter
+// {
+//     public async Task OnFunctionInvocationAsync(FunctionInvocationContext context, Func<FunctionInvocationContext, Task> next)
+//     {
+//         logger.Information("FunctionInvoking - {PluginName}.{FunctionName}", context.Function.PluginName, context.Function.Name);
+//
+//         await next(context);
+//
+//         logger.Information("FunctionInvoked - {PluginName}.{FunctionName}", context.Function.PluginName, context.Function.Name);
+//     }
+// }

--- a/dotnet/development/development.csproj
+++ b/dotnet/development/development.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu.Windows" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.Cuda" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\src\SemanticKernel.Core\SemanticKernel.Core.csproj"/>
+    <ProjectReference Include="..\src\Connectors\Connectors.Onnx\Connectors.Onnx.csproj"/>
+    <ProjectReference Include="..\src\SemanticKernel.Abstractions\SemanticKernel.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>
+  

--- a/dotnet/nuget/nuget-package.props
+++ b/dotnet/nuget/nuget-package.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Central version prefix - applies to all nuget packages. -->
-    <VersionPrefix>1.60.1</VersionPrefix>
+    <VersionPrefix>1.60.0</VersionPrefix>
     <PackageVersion Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</PackageVersion>
     <PackageVersion Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</PackageVersion>
 

--- a/dotnet/nuget/nuget-package.props
+++ b/dotnet/nuget/nuget-package.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Central version prefix - applies to all nuget packages. -->
-    <VersionPrefix>1.60.0</VersionPrefix>
+    <VersionPrefix>1.60.1</VersionPrefix>
     <PackageVersion Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</PackageVersion>
     <PackageVersion Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</PackageVersion>
 

--- a/dotnet/samples/Concepts/Concepts.csproj
+++ b/dotnet/samples/Concepts/Concepts.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyName>Concepts</AssemblyName>

--- a/dotnet/samples/Concepts/FunctionCalling/Onnx_FunctionCalling.cs
+++ b/dotnet/samples/Concepts/FunctionCalling/Onnx_FunctionCalling.cs
@@ -19,17 +19,17 @@ public class Onnx_FunctionCalling(ITestOutputHelper output) : BaseTest(output)
     [Fact]
     public async Task FunctionCallingAutoInvokeAsync()
     {
-        string modelPath = "path/to/your/onnx/model";
+        string modelPath = "D:\\VisionCATS_AI_Agent\\Development\\.cache\\models\\microsoft_Phi_4_multimodal_instruct_onnx-gpu_gpu_int4_rtn_block_32";
         string modelId = "phi-3-mini-4k-instruct";
 
         // Create a kernel with the ONNX function calling chat completion service
         var builder = Kernel.CreateBuilder()
             .AddOnnxRuntimeGenAIFunctionCallingChatCompletion(modelId, modelPath);
-        
+
         // Add a simple plugin with a few functions
         builder.Plugins.AddFromType<TimePlugin>();
         builder.Plugins.AddFromType<MathPlugin>();
-        
+
         Kernel kernel = builder.Build();
 
         // Enable auto-invocation of functions
@@ -51,17 +51,17 @@ public class Onnx_FunctionCalling(ITestOutputHelper output) : BaseTest(output)
     [Fact]
     public async Task FunctionCallingManualInvokeAsync()
     {
-        string modelPath = "path/to/your/onnx/model";
+        string modelPath = "D:\\VisionCATS_AI_Agent\\Development\\.cache\\models\\microsoft_Phi_4_multimodal_instruct_onnx-gpu_gpu_int4_rtn_block_32";
         string modelId = "phi-3-mini-4k-instruct";
 
         // Create a kernel with the ONNX function calling chat completion service
         var builder = Kernel.CreateBuilder()
             .AddOnnxRuntimeGenAIFunctionCallingChatCompletion(modelId, modelPath);
-        
+
         // Add a simple plugin with a few functions
         builder.Plugins.AddFromType<TimePlugin>();
         builder.Plugins.AddFromType<MathPlugin>();
-        
+
         Kernel kernel = builder.Build();
 
         // Enable function calling without auto-invocation
@@ -83,16 +83,16 @@ public class Onnx_FunctionCalling(ITestOutputHelper output) : BaseTest(output)
     [Fact]
     public async Task FunctionCallingSpecificFunctionsAsync()
     {
-        string modelPath = "path/to/your/onnx/model";
+        string modelPath = "D:\\VisionCATS_AI_Agent\\Development\\.cache\\models\\microsoft_Phi_4_multimodal_instruct_onnx-gpu_gpu_int4_rtn_block_32";
         string modelId = "phi-3-mini-4k-instruct";
 
         // Create a kernel with the ONNX function calling chat completion service
         var builder = Kernel.CreateBuilder()
             .AddOnnxRuntimeGenAIFunctionCallingChatCompletion(modelId, modelPath);
-        
+
         // Add a simple plugin with a few functions
         builder.Plugins.AddFromType<MathPlugin>();
-        
+
         Kernel kernel = builder.Build();
 
         // Get specific functions

--- a/dotnet/samples/Concepts/FunctionCalling/Onnx_FunctionCalling.cs
+++ b/dotnet/samples/Concepts/FunctionCalling/Onnx_FunctionCalling.cs
@@ -19,7 +19,7 @@ public class Onnx_FunctionCalling(ITestOutputHelper output) : BaseTest(output)
     [Fact]
     public async Task FunctionCallingAutoInvokeAsync()
     {
-        string modelPath = "D:\\VisionCATS_AI_Agent\\Development\\.cache\\models\\microsoft_Phi_4_multimodal_instruct_onnx-gpu_gpu_int4_rtn_block_32";
+        string modelPath = "path/to/your/onnx/model";
         string modelId = "phi-3-mini-4k-instruct";
 
         // Create a kernel with the ONNX function calling chat completion service
@@ -51,7 +51,7 @@ public class Onnx_FunctionCalling(ITestOutputHelper output) : BaseTest(output)
     [Fact]
     public async Task FunctionCallingManualInvokeAsync()
     {
-        string modelPath = "D:\\VisionCATS_AI_Agent\\Development\\.cache\\models\\microsoft_Phi_4_multimodal_instruct_onnx-gpu_gpu_int4_rtn_block_32";
+        string modelPath = "path/to/your/onnx/model";
         string modelId = "phi-3-mini-4k-instruct";
 
         // Create a kernel with the ONNX function calling chat completion service
@@ -83,7 +83,7 @@ public class Onnx_FunctionCalling(ITestOutputHelper output) : BaseTest(output)
     [Fact]
     public async Task FunctionCallingSpecificFunctionsAsync()
     {
-        string modelPath = "D:\\VisionCATS_AI_Agent\\Development\\.cache\\models\\microsoft_Phi_4_multimodal_instruct_onnx-gpu_gpu_int4_rtn_block_32";
+        string modelPath = "path/to/your/onnx/model";
         string modelId = "phi-3-mini-4k-instruct";
 
         // Create a kernel with the ONNX function calling chat completion service

--- a/dotnet/samples/Concepts/FunctionCalling/Onnx_FunctionCalling.cs
+++ b/dotnet/samples/Concepts/FunctionCalling/Onnx_FunctionCalling.cs
@@ -1,0 +1,170 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Connectors.Onnx;
+
+namespace FunctionCalling;
+
+/// <summary>
+/// This example demonstrates how to use function calling with the ONNX connector.
+/// </summary>
+public class Onnx_FunctionCalling(ITestOutputHelper output) : BaseTest(output)
+{
+    /// <summary>
+    /// Shows how to use function calling with auto-invocation enabled.
+    /// </summary>
+    [Fact]
+    public async Task FunctionCallingAutoInvokeAsync()
+    {
+        string modelPath = "path/to/your/onnx/model";
+        string modelId = "phi-3-mini-4k-instruct";
+
+        // Create a kernel with the ONNX function calling chat completion service
+        var builder = Kernel.CreateBuilder()
+            .AddOnnxRuntimeGenAIFunctionCallingChatCompletion(modelId, modelPath);
+        
+        // Add a simple plugin with a few functions
+        builder.Plugins.AddFromType<TimePlugin>();
+        builder.Plugins.AddFromType<MathPlugin>();
+        
+        Kernel kernel = builder.Build();
+
+        // Enable auto-invocation of functions
+        OnnxRuntimeGenAIPromptExecutionSettings settings = new()
+        {
+            ToolCallBehavior = OnnxToolCallBehavior.AutoInvokeKernelFunctions
+        };
+
+        // Test function calling
+        string prompt = "What time is it? Also, what's 15 + 27?";
+        var result = await kernel.InvokePromptAsync(prompt, new(settings));
+
+        Console.WriteLine($"Result: {result}");
+    }
+
+    /// <summary>
+    /// Shows how to use function calling with manual invocation.
+    /// </summary>
+    [Fact]
+    public async Task FunctionCallingManualInvokeAsync()
+    {
+        string modelPath = "path/to/your/onnx/model";
+        string modelId = "phi-3-mini-4k-instruct";
+
+        // Create a kernel with the ONNX function calling chat completion service
+        var builder = Kernel.CreateBuilder()
+            .AddOnnxRuntimeGenAIFunctionCallingChatCompletion(modelId, modelPath);
+        
+        // Add a simple plugin with a few functions
+        builder.Plugins.AddFromType<TimePlugin>();
+        builder.Plugins.AddFromType<MathPlugin>();
+        
+        Kernel kernel = builder.Build();
+
+        // Enable function calling without auto-invocation
+        OnnxRuntimeGenAIPromptExecutionSettings settings = new()
+        {
+            ToolCallBehavior = OnnxToolCallBehavior.EnableKernelFunctions
+        };
+
+        // Test function calling
+        string prompt = "What time is it?";
+        var result = await kernel.InvokePromptAsync(prompt, new(settings));
+
+        Console.WriteLine($"Result: {result}");
+    }
+
+    /// <summary>
+    /// Shows how to use function calling with specific functions.
+    /// </summary>
+    [Fact]
+    public async Task FunctionCallingSpecificFunctionsAsync()
+    {
+        string modelPath = "path/to/your/onnx/model";
+        string modelId = "phi-3-mini-4k-instruct";
+
+        // Create a kernel with the ONNX function calling chat completion service
+        var builder = Kernel.CreateBuilder()
+            .AddOnnxRuntimeGenAIFunctionCallingChatCompletion(modelId, modelPath);
+        
+        // Add a simple plugin with a few functions
+        builder.Plugins.AddFromType<MathPlugin>();
+        
+        Kernel kernel = builder.Build();
+
+        // Get specific functions
+        var mathPlugin = kernel.Plugins["MathPlugin"];
+        var addFunction = mathPlugin["Add"];
+        var multiplyFunction = mathPlugin["Multiply"];
+
+        // Convert to ONNX functions
+        var onnxFunctions = new[]
+        {
+            addFunction.Metadata.ToOnnxFunction(),
+            multiplyFunction.Metadata.ToOnnxFunction()
+        };
+
+        // Enable specific functions with auto-invocation
+        OnnxRuntimeGenAIPromptExecutionSettings settings = new()
+        {
+            ToolCallBehavior = OnnxToolCallBehavior.EnableFunctions(onnxFunctions, autoInvoke: true)
+        };
+
+        // Test function calling
+        string prompt = "What's 15 + 27 and then multiply that result by 3?";
+        var result = await kernel.InvokePromptAsync(prompt, new(settings));
+
+        Console.WriteLine($"Result: {result}");
+    }
+}
+
+/// <summary>
+/// A plugin that provides time-related functions.
+/// </summary>
+public class TimePlugin
+{
+    [KernelFunction]
+    [Description("Get the current time in UTC")]
+    public DateTime GetCurrentUtcTime()
+    {
+        return DateTime.UtcNow;
+    }
+
+    [KernelFunction]
+    [Description("Get the current time in a specific timezone")]
+    public DateTime GetTimeInTimezone([Description("The timezone ID (e.g., 'America/New_York')")] string timezoneId)
+    {
+        var timeZone = TimeZoneInfo.FindSystemTimeZoneById(timezoneId);
+        return TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, timeZone);
+    }
+}
+
+/// <summary>
+/// A plugin that provides math-related functions.
+/// </summary>
+public class MathPlugin
+{
+    [KernelFunction]
+    [Description("Add two numbers")]
+    public double Add([Description("The first number")] double a, [Description("The second number")] double b)
+    {
+        return a + b;
+    }
+
+    [KernelFunction]
+    [Description("Multiply two numbers")]
+    public double Multiply([Description("The first number")] double a, [Description("The second number")] double b)
+    {
+        return a * b;
+    }
+
+    [KernelFunction]
+    [Description("Calculate the square root of a number")]
+    public double SquareRoot([Description("The number to calculate square root of")] double number)
+    {
+        return Math.Sqrt(number);
+    }
+}

--- a/dotnet/samples/Demos/OnnxFunctionCalling/OnnxFunctionCalling.csproj
+++ b/dotnet/samples/Demos/OnnxFunctionCalling/OnnxFunctionCalling.csproj
@@ -5,6 +5,8 @@
     <NoWarn>$(NoWarn);CA2007,CA2208,CS1591,CA1024,IDE0009,IDE0055,IDE0073,IDE0211,VSTHRD111,SKEXP0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console"/>
     <PackageReference Include="Microsoft.Net.Compilers.Toolset" />
     <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.Cuda" />
     <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu.Windows" />

--- a/dotnet/samples/Demos/OnnxFunctionCalling/OnnxFunctionCalling.csproj
+++ b/dotnet/samples/Demos/OnnxFunctionCalling/OnnxFunctionCalling.csproj
@@ -6,6 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers.Toolset" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.Cuda" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu.Windows" />
     <ProjectReference Include="..\..\..\src\Connectors\Connectors.Onnx\Connectors.Onnx.csproj" />
     <ProjectReference Include="..\..\..\src\SemanticKernel.Abstractions\SemanticKernel.Abstractions.csproj" />
   </ItemGroup>

--- a/dotnet/samples/Demos/OnnxFunctionCalling/OnnxFunctionCalling.csproj
+++ b/dotnet/samples/Demos/OnnxFunctionCalling/OnnxFunctionCalling.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <NoWarn>$(NoWarn);CA2007,CA2208,CS1591,CA1024,IDE0009,IDE0055,IDE0073,IDE0211,VSTHRD111,SKEXP0001</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" />
+    <ProjectReference Include="..\..\..\src\Connectors\Connectors.Onnx\Connectors.Onnx.csproj" />
+    <ProjectReference Include="..\..\..\src\SemanticKernel.Abstractions\SemanticKernel.Abstractions.csproj" />
+  </ItemGroup>
+</Project>

--- a/dotnet/samples/Demos/OnnxFunctionCalling/Plugins/MyAlarmPlugin.cs
+++ b/dotnet/samples/Demos/OnnxFunctionCalling/Plugins/MyAlarmPlugin.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.ComponentModel;
+using Microsoft.SemanticKernel;
+
+namespace OnnxFunctionCalling;
+
+/// <summary>
+/// Class that represents a controllable alarm.
+/// </summary>
+public class MyAlarmPlugin
+{
+    private string _hour;
+
+    public MyAlarmPlugin(string providedHour)
+    {
+        this._hour = providedHour;
+    }
+
+    [KernelFunction, Description("Sets an alarm at the provided time")]
+    public string SetAlarm(string time)
+    {
+        this._hour = time;
+        return GetCurrentAlarm();
+    }
+
+    [KernelFunction, Description("Get current alarm set")]
+    public string GetCurrentAlarm()
+    {
+        return $"Alarm set for {_hour}";
+    }
+}

--- a/dotnet/samples/Demos/OnnxFunctionCalling/Plugins/MyAlarmPlugin.cs
+++ b/dotnet/samples/Demos/OnnxFunctionCalling/Plugins/MyAlarmPlugin.cs
@@ -3,7 +3,7 @@
 using System.ComponentModel;
 using Microsoft.SemanticKernel;
 
-namespace OnnxFunctionCalling;
+namespace OnnxFunctionCalling.Plugins;
 
 /// <summary>
 /// Class that represents a controllable alarm.

--- a/dotnet/samples/Demos/OnnxFunctionCalling/Plugins/MyLightPlugin.cs
+++ b/dotnet/samples/Demos/OnnxFunctionCalling/Plugins/MyLightPlugin.cs
@@ -3,7 +3,7 @@
 using System.ComponentModel;
 using Microsoft.SemanticKernel;
 
-namespace OnnxFunctionCalling;
+namespace OnnxFunctionCalling.Plugins;
 
 /// <summary>
 /// Class that represents a controllable light bulb.

--- a/dotnet/samples/Demos/OnnxFunctionCalling/Plugins/MyLightPlugin.cs
+++ b/dotnet/samples/Demos/OnnxFunctionCalling/Plugins/MyLightPlugin.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.ComponentModel;
+using Microsoft.SemanticKernel;
+
+namespace OnnxFunctionCalling;
+
+/// <summary>
+/// Class that represents a controllable light bulb.
+/// </summary>
+[Description("Represents a light bulb")]
+public class MyLightPlugin(bool turnedOn = false)
+{
+    private bool _turnedOn = turnedOn;
+
+    [KernelFunction, Description("Returns whether this light is on")]
+    public bool IsTurnedOn() => _turnedOn;
+
+    [KernelFunction, Description("Turn on this light")]
+    public void TurnOn() => _turnedOn = true;
+
+    [KernelFunction, Description("Turn off this light")]
+    public void TurnOff() => _turnedOn = false;
+}

--- a/dotnet/samples/Demos/OnnxFunctionCalling/Plugins/MyTimePlugin.cs
+++ b/dotnet/samples/Demos/OnnxFunctionCalling/Plugins/MyTimePlugin.cs
@@ -4,7 +4,7 @@ using System;
 using System.ComponentModel;
 using Microsoft.SemanticKernel;
 
-namespace OnnxFunctionCalling;
+namespace OnnxFunctionCalling.Plugins;
 
 /// <summary>
 /// Simple plugin that just returns the time.

--- a/dotnet/samples/Demos/OnnxFunctionCalling/Plugins/MyTimePlugin.cs
+++ b/dotnet/samples/Demos/OnnxFunctionCalling/Plugins/MyTimePlugin.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.ComponentModel;
+using Microsoft.SemanticKernel;
+
+namespace OnnxFunctionCalling;
+
+/// <summary>
+/// Simple plugin that just returns the time.
+/// </summary>
+public class MyTimePlugin
+{
+    [KernelFunction, Description("Get the current time")]
+    public DateTimeOffset Time() => DateTimeOffset.Now;
+}

--- a/dotnet/samples/Demos/OnnxFunctionCalling/Program.cs
+++ b/dotnet/samples/Demos/OnnxFunctionCalling/Program.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.Connectors.Onnx;
+using OnnxFunctionCalling;
+
+var builder = Kernel.CreateBuilder();
+var modelId = "llama3.2";
+var modelPath = "D:\\VisionCATS_AI_Agent\\Development\\.cache\\models\\microsoft_Phi_4_multimodal_instruct_onnx-gpu_gpu_int4_rtn_block_32";
+
+builder.Services.AddOnnxRuntimeGenAIChatCompletion(modelId, modelPath);
+
+builder.Plugins
+    .AddFromType<MyTimePlugin>()
+    .AddFromObject(new MyLightPlugin(turnedOn: true))
+    .AddFromObject(new MyAlarmPlugin("11"));
+
+var kernel = builder.Build();
+var chatCompletionService = kernel.GetRequiredService<IChatCompletionService>();
+var settings = new OnnxRuntimeGenAIPromptExecutionSettings
+{
+    FunctionChoiceBehavior = FunctionChoiceBehavior.Auto()
+};
+
+Console.WriteLine("""
+                  Ask questions or give instructions to the copilot such as:
+                  - Change the alarm to 8
+                  - What is the current alarm set?
+                  - Is the light on?
+                  - Turn the light off please.
+                  - Set an alarm for 6:00 am.
+                  """);
+
+Console.Write("> ");
+
+string? input = null;
+while ((input = Console.ReadLine()) is not null)
+{
+    Console.WriteLine();
+
+    try
+    {
+        ChatMessageContent chatResult = await chatCompletionService.GetChatMessageContentAsync(input, settings, kernel);
+        Console.Write($"\n>>> Result: {chatResult}\n\n> ");
+    }
+    catch (Exception ex)
+    {
+        Console.WriteLine($"Error: {ex.Message}\n\n> ");
+    }
+}

--- a/dotnet/samples/Demos/OnnxFunctionCalling/Program.cs
+++ b/dotnet/samples/Demos/OnnxFunctionCalling/Program.cs
@@ -71,11 +71,12 @@ builder.Plugins
 Kernel kernel = builder.Build();
 
 ChatHistory history = [];
-// history.AddSystemMessage("""
-//                          You are a helpful assistant.
-//                          Answer questions directly and concisely.
-//                          Provide brief, clear responses without unnecessary explanations.
-//                          """);
+history.AddSystemMessage("""
+                         You are a helpful assistant.
+                         You are not restricted to using the provided plugins,
+                         and you can use information from your training.
+                         Please explain your reasoning with the response.
+                         """);
 
 IChatCompletionService chatCompletionService = kernel.GetRequiredService<IChatCompletionService>();
 OnnxRuntimeGenAIPromptExecutionSettings settings = new()

--- a/dotnet/samples/Demos/OnnxFunctionCalling/Program.cs
+++ b/dotnet/samples/Demos/OnnxFunctionCalling/Program.cs
@@ -2,13 +2,17 @@
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.Onnx;
-using OnnxFunctionCalling;
+using OnnxFunctionCalling.Plugins;
 
 var builder = Kernel.CreateBuilder();
-var modelId = "llama3.2";
+var modelId = "Phi_4_multimodal_instruct";
 var modelPath = "D:\\VisionCATS_AI_Agent\\Development\\.cache\\models\\microsoft_Phi_4_multimodal_instruct_onnx-gpu_gpu_int4_rtn_block_32";
 
-builder.Services.AddOnnxRuntimeGenAIChatCompletion(modelId, modelPath);
+builder.AddOnnxRuntimeGenAIFunctionCallingChatCompletion(
+    modelPath: modelPath,
+    serviceId: "onnx",
+    providers: ["cuda"]
+);
 
 builder.Plugins
     .AddFromType<MyTimePlugin>()

--- a/dotnet/samples/Demos/OpenAIFunctionCalling/OpenAIFunctionCalling.csproj
+++ b/dotnet/samples/Demos/OpenAIFunctionCalling/OpenAIFunctionCalling.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);VSTHRD111,CA2007,CS8618,CS1591,CA1052,SKEXP0001</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder"/>
+    <ProjectReference Include="..\..\..\src\Connectors\Connectors.AzureOpenAI\Connectors.AzureOpenAI.csproj"/>
+    <ProjectReference Include="..\..\..\src\SemanticKernel.Core\SemanticKernel.Core.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/dotnet/samples/Demos/OpenAIFunctionCalling/Plugins/MyAlarmPlugin.cs
+++ b/dotnet/samples/Demos/OpenAIFunctionCalling/Plugins/MyAlarmPlugin.cs
@@ -3,7 +3,7 @@
 using System.ComponentModel;
 using Microsoft.SemanticKernel;
 
-namespace OnnxFunctionCalling.Plugins;
+namespace OpenAIFunctionCalling.Plugins;
 
 /// <summary>
 /// Class that represents a controllable alarm.

--- a/dotnet/samples/Demos/OpenAIFunctionCalling/Plugins/MyLightPlugin.cs
+++ b/dotnet/samples/Demos/OpenAIFunctionCalling/Plugins/MyLightPlugin.cs
@@ -3,7 +3,7 @@
 using System.ComponentModel;
 using Microsoft.SemanticKernel;
 
-namespace OnnxFunctionCalling.Plugins;
+namespace OpenAIFunctionCalling.Plugins;
 
 /// <summary>
 /// Class that represents a controllable light bulb.

--- a/dotnet/samples/Demos/OpenAIFunctionCalling/Plugins/MyTimePlugin.cs
+++ b/dotnet/samples/Demos/OpenAIFunctionCalling/Plugins/MyTimePlugin.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.ComponentModel;
+using Microsoft.SemanticKernel;
+
+namespace OpenAIFunctionCalling.Plugins;
+
+/// <summary>
+/// Simple plugin that just returns the time.
+/// </summary>
+public class MyTimePlugin
+{
+    [KernelFunction]
+    [Description("Get the current time")]
+    public DateTimeOffset Time() => DateTimeOffset.Now;
+}

--- a/dotnet/src/Connectors/Connectors.Onnx.UnitTests/OnnxFunctionCallingTests.cs
+++ b/dotnet/src/Connectors/Connectors.Onnx.UnitTests/OnnxFunctionCallingTests.cs
@@ -1,0 +1,280 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Connectors.Onnx;
+using Xunit;
+
+namespace Microsoft.SemanticKernel.Connectors.Onnx.UnitTests;
+
+/// <summary>
+/// Unit tests for ONNX function calling functionality.
+/// </summary>
+public sealed class OnnxFunctionCallingTests
+{
+    [Fact]
+    public void OnnxToolCallBehavior_EnableKernelFunctions_CreatesCorrectBehavior()
+    {
+        // Arrange & Act
+        var behavior = OnnxToolCallBehavior.EnableKernelFunctions;
+
+        // Assert
+        Assert.NotNull(behavior);
+        Assert.False(behavior.AutoInvoke);
+        Assert.True(behavior.AllowAnyRequestedKernelFunction);
+        Assert.Equal(0, behavior.MaximumAutoInvokeAttempts);
+    }
+
+    [Fact]
+    public void OnnxToolCallBehavior_AutoInvokeKernelFunctions_CreatesCorrectBehavior()
+    {
+        // Arrange & Act
+        var behavior = OnnxToolCallBehavior.AutoInvokeKernelFunctions;
+
+        // Assert
+        Assert.NotNull(behavior);
+        Assert.True(behavior.AutoInvoke);
+        Assert.True(behavior.AllowAnyRequestedKernelFunction);
+        Assert.Equal(128, behavior.MaximumAutoInvokeAttempts);
+    }
+
+    [Fact]
+    public void OnnxToolCallBehavior_EnableFunctions_CreatesCorrectBehavior()
+    {
+        // Arrange
+        var functions = new[]
+        {
+            new OnnxFunction("TestFunction", "A test function"),
+            new OnnxFunction("AnotherFunction", "Another test function")
+        };
+
+        // Act
+        var behavior = OnnxToolCallBehavior.EnableFunctions(functions, autoInvoke: true);
+
+        // Assert
+        Assert.NotNull(behavior);
+        Assert.True(behavior.AutoInvoke);
+        Assert.Equal(128, behavior.MaximumAutoInvokeAttempts);
+    }
+
+    [Fact]
+    public void OnnxToolCallBehavior_RequireFunction_CreatesCorrectBehavior()
+    {
+        // Arrange
+        var function = new OnnxFunction("RequiredFunction", "A required function");
+
+        // Act
+        var behavior = OnnxToolCallBehavior.RequireFunction(function, autoInvoke: false);
+
+        // Assert
+        Assert.NotNull(behavior);
+        Assert.False(behavior.AutoInvoke);
+        Assert.Equal(0, behavior.MaximumAutoInvokeAttempts);
+    }
+
+    [Fact]
+    public void OnnxFunction_Constructor_InitializesCorrectly()
+    {
+        // Arrange
+        var functionName = "TestFunction";
+        var description = "A test function";
+
+        // Act
+        var function = new OnnxFunction(functionName, description);
+
+        // Assert
+        Assert.Equal(functionName, function.FunctionName);
+        Assert.Equal(description, function.Description);
+        Assert.NotNull(function.Parameters);
+        Assert.Empty(function.Parameters);
+        Assert.Null(function.ReturnParameter);
+    }
+
+    [Fact]
+    public void OnnxFunction_WithParameters_InitializesCorrectly()
+    {
+        // Arrange
+        var functionName = "TestFunction";
+        var description = "A test function";
+        var parameters = new[]
+        {
+            new KernelParameterMetadata("param1")
+            {
+                Description = "First parameter",
+                ParameterType = typeof(string),
+                IsRequired = true
+            },
+            new KernelParameterMetadata("param2")
+            {
+                Description = "Second parameter",
+                ParameterType = typeof(int),
+                IsRequired = false
+            }
+        };
+
+        // Act
+        var function = new OnnxFunction(functionName, description, parameters);
+
+        // Assert
+        Assert.Equal(functionName, function.FunctionName);
+        Assert.Equal(description, function.Description);
+        Assert.Equal(2, function.Parameters.Count);
+        Assert.Equal("param1", function.Parameters[0].Name);
+        Assert.Equal("param2", function.Parameters[1].Name);
+    }
+
+    [Fact]
+    public void OnnxFunction_ToFunctionDefinition_GeneratesCorrectSchema()
+    {
+        // Arrange
+        var functionName = "TestFunction";
+        var description = "A test function";
+        var parameters = new[]
+        {
+            new KernelParameterMetadata("stringParam")
+            {
+                Description = "A string parameter",
+                ParameterType = typeof(string),
+                IsRequired = true
+            },
+            new KernelParameterMetadata("intParam")
+            {
+                Description = "An integer parameter",
+                ParameterType = typeof(int),
+                IsRequired = false
+            }
+        };
+
+        var function = new OnnxFunction(functionName, description, parameters);
+
+        // Act
+        var schema = function.ToFunctionDefinition();
+
+        // Assert
+        Assert.NotNull(schema);
+        Assert.Equal(functionName, schema["name"]?.ToString());
+        Assert.Equal(description, schema["description"]?.ToString());
+        Assert.NotNull(schema["parameters"]);
+        
+        var parametersSchema = schema["parameters"];
+        Assert.Equal("object", parametersSchema?["type"]?.ToString());
+        Assert.NotNull(parametersSchema?["properties"]);
+        Assert.NotNull(parametersSchema?["required"]);
+    }
+
+    [Fact]
+    public void OnnxFunction_ParseFunctionCall_WithValidJson_ParsesCorrectly()
+    {
+        // Arrange
+        var functionName = "TestFunction";
+        var argumentsJson = """{"param1": "value1", "param2": 42}""";
+
+        // Act
+        var functionCall = OnnxFunction.ParseFunctionCall(functionName, argumentsJson);
+
+        // Assert
+        Assert.NotNull(functionCall);
+        Assert.Equal(functionName, functionCall.FunctionName);
+        Assert.Equal(2, functionCall.Arguments.Count);
+        Assert.Contains("param1", functionCall.Arguments);
+        Assert.Contains("param2", functionCall.Arguments);
+    }
+
+    [Fact]
+    public void OnnxFunction_ParseFunctionCall_WithInvalidJson_FallsBackToSingleArgument()
+    {
+        // Arrange
+        var functionName = "TestFunction";
+        var invalidJson = "not valid json";
+
+        // Act
+        var functionCall = OnnxFunction.ParseFunctionCall(functionName, invalidJson);
+
+        // Assert
+        Assert.NotNull(functionCall);
+        Assert.Equal(functionName, functionCall.FunctionName);
+        Assert.Single(functionCall.Arguments);
+        Assert.Contains("input", functionCall.Arguments);
+        Assert.Equal(invalidJson, functionCall.Arguments["input"]);
+    }
+
+    [Fact]
+    public void OnnxFunction_CreateFunctionResult_CreatesCorrectResult()
+    {
+        // Arrange
+        var functionCall = new FunctionCallContent("TestFunction", new KernelArguments());
+        var result = "Test result";
+
+        // Act
+        var functionResult = OnnxFunction.CreateFunctionResult(functionCall, result);
+
+        // Assert
+        Assert.NotNull(functionResult);
+        Assert.Equal(functionCall, functionResult.FunctionCall);
+        Assert.Equal(result, functionResult.Result);
+    }
+
+    [Fact]
+    public void OnnxFunctionExtensions_ToOnnxFunction_ConvertsCorrectly()
+    {
+        // Arrange
+        var metadata = new KernelFunctionMetadata("TestFunction")
+        {
+            Description = "A test function",
+            Parameters = new[]
+            {
+                new KernelParameterMetadata("param1")
+                {
+                    Description = "First parameter",
+                    ParameterType = typeof(string),
+                    IsRequired = true
+                }
+            }
+        };
+
+        // Act
+        var onnxFunction = metadata.ToOnnxFunction();
+
+        // Assert
+        Assert.NotNull(onnxFunction);
+        Assert.Equal(metadata.Name, onnxFunction.FunctionName);
+        Assert.Equal(metadata.Description, onnxFunction.Description);
+        Assert.Equal(metadata.Parameters.Count, onnxFunction.Parameters.Count);
+    }
+
+    [Fact]
+    public void OnnxRuntimeGenAIPromptExecutionSettings_ToolCallBehavior_SetAndGetCorrectly()
+    {
+        // Arrange
+        var settings = new OnnxRuntimeGenAIPromptExecutionSettings();
+        var behavior = OnnxToolCallBehavior.AutoInvokeKernelFunctions;
+
+        // Act
+        settings.ToolCallBehavior = behavior;
+
+        // Assert
+        Assert.Equal(behavior, settings.ToolCallBehavior);
+    }
+}
+
+/// <summary>
+/// Sample plugin for testing function calling.
+/// </summary>
+public class TestPlugin
+{
+    [KernelFunction]
+    [Description("Get a test string")]
+    public string GetTestString()
+    {
+        return "Test string";
+    }
+
+    [KernelFunction]
+    [Description("Add two numbers")]
+    public int Add([Description("First number")] int a, [Description("Second number")] int b)
+    {
+        return a + b;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Onnx/Connectors.Onnx.csproj
+++ b/dotnet/src/Connectors/Connectors.Onnx/Connectors.Onnx.csproj
@@ -2,16 +2,27 @@
 
   <PropertyGroup>
     <!-- THIS PROPERTY GROUP MUST COME FIRST -->
-    <AssemblyName>Microsoft.SemanticKernel.Connectors.Onnx</AssemblyName>
+    <AssemblyName>Camag.SemanticKernel.Connectors.Onnx</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
-    <VersionSuffix>alpha</VersionSuffix>
     <NoWarn>$(NoWarn);SKEXP0001;SYSLIB1222</NoWarn>
   </PropertyGroup>
 
   <!-- IMPORT NUGET PACKAGE SHARED PROPERTIES -->
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
+
+  <!-- OVERRIDE MICROSOFT-SPECIFIC PROPERTIES -->
+  <PropertyGroup>
+    <Authors>Camag</Authors>
+    <Company>Camag</Company>
+    <Product>Semantic Kernel ONNX Connector</Product>
+    <Description>Semantic Kernel connectors for the ONNX runtime. Contains clients for text embedding generation and chat completion.</Description>
+    <PackageTags>AI, Artificial Intelligence, SDK, ONNX, Semantic Kernel</PackageTags>
+    <PackageId>$(AssemblyName)</PackageId>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Copyright>© Camag. All rights reserved.</Copyright>
+  </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/Verify.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
@@ -26,23 +37,39 @@
     <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Text/OptionalBoolJsonConverter.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
     <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Text/ExceptionJsonConverter.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
     <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/System/AppContextSwitchHelper.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/connectors/AI/FunctionCalling/*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)"/>
   </ItemGroup>
 
   <PropertyGroup>
     <Title>Semantic Kernel - ONNX Connectors</Title>
-    <Description>Semantic Kernel connectors for the ONNX runtime. Contains clients for text embedding generation.</Description>
+    <Description>Semantic Kernel connectors for the ONNX runtime. Contains clients for text embedding generation and chat completion.</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\SemanticKernel.Core\SemanticKernel.Core.csproj" />
+    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" />
+    <PackageReference Include="Microsoft.SemanticKernel.Core" />
+    <PackageReference Include="Microsoft.Extensions.AI" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="FastBertTokenizer" />
     <PackageReference Include="Microsoft.ML.OnnxRuntime" />
+  </ItemGroup>
+
+  <!-- Temporarily disable SourceLink for build -->
+  <PropertyGroup>
+    <IncludeSymbols>false</IncludeSymbols>
+    <PublishRepositoryUrl>false</PublishRepositoryUrl>
+  </PropertyGroup>
+
+  <!-- Override SourceLink inclusion -->
+  <ItemGroup>
+    <PackageReference Remove="Microsoft.SourceLink.GitHub" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI" Condition=" '$(Configuration)' == 'Debug' OR '$(Configuration)' == 'Release' " />
     <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.Cuda" Condition=" '$(Configuration)' == 'Debug_Cuda' OR '$(Configuration)' == 'Release_Cuda' " />
-    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Condition=" '$(Configuration)' == 'Debug_DirectML' OR '$(Configuration)' == 'Release_DirectML' " />    
+    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Condition=" '$(Configuration)' == 'Debug_DirectML' OR '$(Configuration)' == 'Release_DirectML' " />
   </ItemGroup>
 
 </Project>

--- a/dotnet/src/Connectors/Connectors.Onnx/Connectors.Onnx.csproj
+++ b/dotnet/src/Connectors/Connectors.Onnx/Connectors.Onnx.csproj
@@ -10,33 +10,36 @@
   </PropertyGroup>
 
   <!-- IMPORT NUGET PACKAGE SHARED PROPERTIES -->
-  <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
+  <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props"/>
 
   <!-- OVERRIDE MICROSOFT-SPECIFIC PROPERTIES -->
   <PropertyGroup>
     <Authors>Camag</Authors>
     <Company>Camag</Company>
     <Product>Semantic Kernel ONNX Connector</Product>
-    <Description>Semantic Kernel connectors for the ONNX runtime. Contains clients for text embedding generation and chat completion.</Description>
+    <Description>
+      Modified version of Semantic Kernel connectors for the ONNX runtime. Contains clients for text embedding generation and chat completion.
+      It enables to configure the providers (eg. CUDA) without modifying the genai_config.json and to do function calling (tested with microsoft/Phi-4-multimodal-instruct-onnx)
+    </Description>
     <PackageTags>AI, Artificial Intelligence, SDK, ONNX, Semantic Kernel</PackageTags>
     <PackageId>$(AssemblyName)</PackageId>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Copyright>© Camag. All rights reserved.</Copyright>
+    <Copyright>© Microsoft . All rights reserved.</Copyright>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/Verify.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
-    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/NullableAttributes.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
-    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/ExperimentalAttribute.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
-    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/CompilerServicesAttributes.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
-    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/IsExternalInit.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
-    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/RequiresUnreferencedCodeAttribute.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
-    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/RequiresDynamicCodeAttribute.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
-    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/UnconditionalSuppressMessageAttribute.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
-    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Text/JsonOptionsCache.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
-    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Text/OptionalBoolJsonConverter.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
-    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Text/ExceptionJsonConverter.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
-    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/System/AppContextSwitchHelper.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/Verify.cs" Link="%(RecursiveDir)%(Filename)%(Extension)"/>
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/NullableAttributes.cs" Link="%(RecursiveDir)%(Filename)%(Extension)"/>
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/ExperimentalAttribute.cs" Link="%(RecursiveDir)%(Filename)%(Extension)"/>
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/CompilerServicesAttributes.cs" Link="%(RecursiveDir)%(Filename)%(Extension)"/>
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/IsExternalInit.cs" Link="%(RecursiveDir)%(Filename)%(Extension)"/>
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/RequiresUnreferencedCodeAttribute.cs" Link="%(RecursiveDir)%(Filename)%(Extension)"/>
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/RequiresDynamicCodeAttribute.cs" Link="%(RecursiveDir)%(Filename)%(Extension)"/>
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/UnconditionalSuppressMessageAttribute.cs" Link="%(RecursiveDir)%(Filename)%(Extension)"/>
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Text/JsonOptionsCache.cs" Link="%(RecursiveDir)%(Filename)%(Extension)"/>
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Text/OptionalBoolJsonConverter.cs" Link="%(RecursiveDir)%(Filename)%(Extension)"/>
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Text/ExceptionJsonConverter.cs" Link="%(RecursiveDir)%(Filename)%(Extension)"/>
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/System/AppContextSwitchHelper.cs" Link="%(RecursiveDir)%(Filename)%(Extension)"/>
     <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/connectors/AI/FunctionCalling/*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)"/>
   </ItemGroup>
 
@@ -46,13 +49,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" />
-    <PackageReference Include="Microsoft.SemanticKernel.Core" />
-    <PackageReference Include="Microsoft.Extensions.AI" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="Microsoft.Extensions.Logging" />
-    <PackageReference Include="FastBertTokenizer" />
-    <PackageReference Include="Microsoft.ML.OnnxRuntime" />
+    <PackageReference Include="Microsoft.SemanticKernel.Abstractions"/>
+    <PackageReference Include="Microsoft.SemanticKernel.Core"/>
+    <PackageReference Include="Microsoft.Extensions.AI"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
+    <PackageReference Include="Microsoft.Extensions.Logging"/>
+    <PackageReference Include="FastBertTokenizer"/>
+    <PackageReference Include="Microsoft.ML.OnnxRuntime"/>
   </ItemGroup>
 
   <!-- Temporarily disable SourceLink for build -->
@@ -63,13 +66,13 @@
 
   <!-- Override SourceLink inclusion -->
   <ItemGroup>
-    <PackageReference Remove="Microsoft.SourceLink.GitHub" />
+    <PackageReference Remove="Microsoft.SourceLink.GitHub"/>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI" Condition=" '$(Configuration)' == 'Debug' OR '$(Configuration)' == 'Release' " />
-    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.Cuda" Condition=" '$(Configuration)' == 'Debug_Cuda' OR '$(Configuration)' == 'Release_Cuda' " />
-    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Condition=" '$(Configuration)' == 'Debug_DirectML' OR '$(Configuration)' == 'Release_DirectML' " />
+    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI" Condition=" '$(Configuration)' == 'Debug' OR '$(Configuration)' == 'Release' "/>
+    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.Cuda" Condition=" '$(Configuration)' == 'Debug_Cuda' OR '$(Configuration)' == 'Release_Cuda' "/>
+    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Condition=" '$(Configuration)' == 'Debug_DirectML' OR '$(Configuration)' == 'Release_DirectML' "/>
   </ItemGroup>
 
 </Project>

--- a/dotnet/src/Connectors/Connectors.Onnx/Connectors.Onnx.csproj
+++ b/dotnet/src/Connectors/Connectors.Onnx/Connectors.Onnx.csproj
@@ -2,77 +2,48 @@
 
   <PropertyGroup>
     <!-- THIS PROPERTY GROUP MUST COME FIRST -->
-    <AssemblyName>Camag.SemanticKernel.Connectors.Onnx</AssemblyName>
+    <AssemblyName>Microsoft.SemanticKernel.Connectors.Onnx</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
+    <VersionSuffix>alpha</VersionSuffix>
     <NoWarn>$(NoWarn);SKEXP0001;SYSLIB1222</NoWarn>
   </PropertyGroup>
 
   <!-- IMPORT NUGET PACKAGE SHARED PROPERTIES -->
-  <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props"/>
-
-  <!-- OVERRIDE MICROSOFT-SPECIFIC PROPERTIES -->
-  <PropertyGroup>
-    <Authors>Camag</Authors>
-    <Company>Camag</Company>
-    <Product>Semantic Kernel ONNX Connector</Product>
-    <Description>
-      Modified version of Semantic Kernel connectors for the ONNX runtime. Contains clients for text embedding generation and chat completion.
-      It enables to configure the providers (eg. CUDA) without modifying the genai_config.json and to do function calling (tested with microsoft/Phi-4-multimodal-instruct-onnx)
-    </Description>
-    <PackageTags>AI, Artificial Intelligence, SDK, ONNX, Semantic Kernel</PackageTags>
-    <PackageId>$(AssemblyName)</PackageId>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Copyright>© Microsoft . All rights reserved.</Copyright>
-  </PropertyGroup>
+  <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
 
   <ItemGroup>
-    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/Verify.cs" Link="%(RecursiveDir)%(Filename)%(Extension)"/>
-    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/NullableAttributes.cs" Link="%(RecursiveDir)%(Filename)%(Extension)"/>
-    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/ExperimentalAttribute.cs" Link="%(RecursiveDir)%(Filename)%(Extension)"/>
-    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/CompilerServicesAttributes.cs" Link="%(RecursiveDir)%(Filename)%(Extension)"/>
-    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/IsExternalInit.cs" Link="%(RecursiveDir)%(Filename)%(Extension)"/>
-    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/RequiresUnreferencedCodeAttribute.cs" Link="%(RecursiveDir)%(Filename)%(Extension)"/>
-    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/RequiresDynamicCodeAttribute.cs" Link="%(RecursiveDir)%(Filename)%(Extension)"/>
-    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/UnconditionalSuppressMessageAttribute.cs" Link="%(RecursiveDir)%(Filename)%(Extension)"/>
-    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Text/JsonOptionsCache.cs" Link="%(RecursiveDir)%(Filename)%(Extension)"/>
-    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Text/OptionalBoolJsonConverter.cs" Link="%(RecursiveDir)%(Filename)%(Extension)"/>
-    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Text/ExceptionJsonConverter.cs" Link="%(RecursiveDir)%(Filename)%(Extension)"/>
-    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/System/AppContextSwitchHelper.cs" Link="%(RecursiveDir)%(Filename)%(Extension)"/>
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/Verify.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/NullableAttributes.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/ExperimentalAttribute.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/CompilerServicesAttributes.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/IsExternalInit.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/RequiresUnreferencedCodeAttribute.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/RequiresDynamicCodeAttribute.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/UnconditionalSuppressMessageAttribute.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Text/JsonOptionsCache.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Text/OptionalBoolJsonConverter.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Text/ExceptionJsonConverter.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/System/AppContextSwitchHelper.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
     <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/connectors/AI/FunctionCalling/*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)"/>
   </ItemGroup>
 
   <PropertyGroup>
     <Title>Semantic Kernel - ONNX Connectors</Title>
-    <Description>Semantic Kernel connectors for the ONNX runtime. Contains clients for text embedding generation and chat completion.</Description>
+    <Description>Semantic Kernel connectors for the ONNX runtime. Contains clients for text embedding generation.</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel.Abstractions"/>
-    <PackageReference Include="Microsoft.SemanticKernel.Core"/>
-    <PackageReference Include="Microsoft.Extensions.AI"/>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
-    <PackageReference Include="Microsoft.Extensions.Logging"/>
-    <PackageReference Include="FastBertTokenizer"/>
-    <PackageReference Include="Microsoft.ML.OnnxRuntime"/>
-  </ItemGroup>
-
-  <!-- Temporarily disable SourceLink for build -->
-  <PropertyGroup>
-    <IncludeSymbols>false</IncludeSymbols>
-    <PublishRepositoryUrl>false</PublishRepositoryUrl>
-  </PropertyGroup>
-
-  <!-- Override SourceLink inclusion -->
-  <ItemGroup>
-    <PackageReference Remove="Microsoft.SourceLink.GitHub"/>
+    <ProjectReference Include="..\..\SemanticKernel.Core\SemanticKernel.Core.csproj" />
+    <PackageReference Include="FastBertTokenizer" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI" Condition=" '$(Configuration)' == 'Debug' OR '$(Configuration)' == 'Release' "/>
-    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.Cuda" Condition=" '$(Configuration)' == 'Debug_Cuda' OR '$(Configuration)' == 'Release_Cuda' "/>
-    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Condition=" '$(Configuration)' == 'Debug_DirectML' OR '$(Configuration)' == 'Release_DirectML' "/>
+    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI" Condition=" '$(Configuration)' == 'Debug' OR '$(Configuration)' == 'Release' " />
+    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.Cuda" Condition=" '$(Configuration)' == 'Debug_Cuda' OR '$(Configuration)' == 'Release_Cuda' " />
+    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Condition=" '$(Configuration)' == 'Debug_DirectML' OR '$(Configuration)' == 'Release_DirectML' " />    
   </ItemGroup>
 
 </Project>

--- a/dotnet/src/Connectors/Connectors.Onnx/Internal/OnnxFunctionCallParser.cs
+++ b/dotnet/src/Connectors/Connectors.Onnx/Internal/OnnxFunctionCallParser.cs
@@ -1,0 +1,269 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace Microsoft.SemanticKernel.Connectors.Onnx.Internal;
+
+/// <summary>
+/// Handles parsing of function calls from model responses.
+/// </summary>
+internal sealed class OnnxFunctionCallParser
+{
+    private readonly ILogger _logger;
+
+    public OnnxFunctionCallParser(ILogger? logger = null)
+    {
+        this._logger = logger ?? NullLogger.Instance;
+    }
+
+    /// <summary>
+    /// Checks if the content contains a function call pattern.
+    /// </summary>
+    public bool ContainsFunctionCall(string content)
+    {
+        if (string.IsNullOrEmpty(content))
+        {
+            return false;
+        }
+
+        // Check for JSON function call pattern
+        if (content.Contains("function_call") && content.Contains("{") && content.Contains("}"))
+        {
+            return true;
+        }
+
+        // Check for code block with function call
+        if (content.Contains("```") && content.Contains("function_call"))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Tries to parse a function call with response format from the model's response.
+    /// </summary>
+    public (FunctionCallContent? FunctionCall, string? ResponseFormat)? TryParseFunctionCallWithResponse(string? content)
+    {
+        if (string.IsNullOrEmpty(content))
+        {
+            return null;
+        }
+
+        this._logger.LogInformation("Attempting to parse function call from content: {Content}", content);
+
+        // First, try to parse the entire content as pure JSON with response format
+        var resultFromContent = TryParseJsonFunctionCallWithResponse(content.Trim());
+        if (resultFromContent != null)
+        {
+            this._logger.LogInformation("Successfully parsed function call from pure JSON content: {FunctionName}", resultFromContent.Value.FunctionCall?.FunctionName);
+            return resultFromContent;
+        }
+
+        // --- Robustness: Try to fix missing closing brace ---
+        var trimmed = content.Trim();
+        if (trimmed.StartsWith("{") && trimmed.Contains("function_call") && !trimmed.EndsWith("}"))
+        {
+            var fixedJson = trimmed + "}";
+            var fixedResult = TryParseJsonFunctionCallWithResponse(fixedJson);
+            if (fixedResult != null)
+            {
+                this._logger.LogInformation("Successfully parsed function call from auto-corrected JSON (added closing brace)");
+                return fixedResult;
+            }
+        }
+        // -----------------------------------------------------
+
+        // Try to extract JSON from the first line and natural language from the rest
+        var lines = content.Split('\n');
+        if (lines.Length >= 2)
+        {
+            var firstLine = lines[0].Trim();
+            var remainingText = string.Join("\n", lines.Skip(1)).Trim();
+
+            // Check if first line is JSON with empty function_call
+            var jsonResult = TryParseJsonFunctionCallWithResponse(firstLine);
+            if (jsonResult != null && jsonResult.Value.FunctionCall == null)
+            {
+                // Empty function_call with natural language response
+                this._logger.LogInformation("Successfully parsed empty function call with natural language response");
+                return (null, remainingText);
+            }
+        }
+
+        // If not pure JSON, try to extract JSON from code blocks (```json ... ```)
+        var jsonContent = ExtractJsonFromCodeBlock(content);
+        if (!string.IsNullOrEmpty(jsonContent))
+        {
+            this._logger.LogInformation("Extracted JSON from code block: {JsonContent}", jsonContent);
+            var result = TryParseJsonFunctionCallWithResponse(jsonContent);
+            if (result != null)
+            {
+                this._logger.LogInformation("Successfully parsed function call from code block: {FunctionName}", result.Value.FunctionCall?.FunctionName);
+                return result;
+            }
+        }
+
+        // Fallback: try to parse without response format
+        var functionCallFromContent = TryParseJsonFunctionCall(content.Trim());
+        if (functionCallFromContent != null)
+        {
+            this._logger.LogInformation("Successfully parsed function call from pure JSON content (no response format): {FunctionName}", functionCallFromContent.FunctionName);
+            return (functionCallFromContent, null);
+        }
+
+        // If JSON parsing fails, try to extract function call using regex
+        var functionCallMatch = Regex.Match(content, @"(?:function_call|call|invoke)\s*:?\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\(([^)]*)\)",
+            RegexOptions.IgnoreCase);
+        if (functionCallMatch.Success)
+        {
+            var functionName = functionCallMatch.Groups[1].Value;
+            var argumentsString = functionCallMatch.Groups[2].Value;
+
+            this._logger.LogInformation("Successfully parsed function call using regex: {FunctionName}", functionName);
+            var functionCall = OnnxFunction.ParseFunctionCall(functionName, argumentsString);
+            return (functionCall, null);
+        }
+
+        this._logger.LogInformation("Failed to parse function call from content");
+        return null;
+    }
+
+    /// <summary>
+    /// Tries to parse a function call from the model's response (legacy method for backward compatibility).
+    /// </summary>
+    public FunctionCallContent? TryParseFunctionCall(string? content)
+    {
+        var result = TryParseFunctionCallWithResponse(content);
+        return result?.FunctionCall;
+    }
+
+    /// <summary>
+    /// Extracts JSON content from markdown code blocks.
+    /// </summary>
+    private static string? ExtractJsonFromCodeBlock(string content)
+    {
+        // Match ```json ... ``` or ``` ... ``` patterns
+        var codeBlockMatch = Regex.Match(content, @"```(?:json)?\s*\n?(.*?)\n?```", RegexOptions.Singleline | RegexOptions.IgnoreCase);
+        if (codeBlockMatch.Success)
+        {
+            return codeBlockMatch.Groups[1].Value.Trim();
+        }
+
+        // Match `{...}` inline code blocks
+        var inlineCodeMatch = Regex.Match(content, @"`(\{.*?\})`", RegexOptions.Singleline);
+        if (inlineCodeMatch.Success)
+        {
+            return inlineCodeMatch.Groups[1].Value.Trim();
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Tries to parse a function call from JSON content.
+    /// </summary>
+    private static FunctionCallContent? TryParseJsonFunctionCall(string jsonContent)
+    {
+        try
+        {
+            var jsonDocument = JsonDocument.Parse(jsonContent);
+            if (jsonDocument.RootElement.TryGetProperty("function_call", out var functionCallElement))
+            {
+                if (functionCallElement.TryGetProperty("name", out var nameElement))
+                {
+                    var functionName = nameElement.GetString();
+                    
+                    if (!string.IsNullOrEmpty(functionName))
+                    {
+                        // Try to get arguments, use empty object if not present
+                        var argumentsJson = "{}";
+                        if (functionCallElement.TryGetProperty("arguments", out var argumentsElement))
+                        {
+                            argumentsJson = argumentsElement.GetRawText();
+                        }
+                        
+                        return OnnxFunction.ParseFunctionCall(functionName, argumentsJson);
+                    }
+                }
+            }
+        }
+        catch (JsonException)
+        {
+            // JSON parsing failed, return null to try other methods
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Tries to parse a function call with response format from JSON content.
+    /// </summary>
+    private static (FunctionCallContent? FunctionCall, string? ResponseFormat)? TryParseJsonFunctionCallWithResponse(string jsonContent)
+    {
+        try
+        {
+            var jsonDocument = JsonDocument.Parse(jsonContent);
+            if (jsonDocument.RootElement.TryGetProperty("function_call", out var functionCallElement))
+            {
+                // Check for response_format first
+                string? responseFormat = null;
+                if (jsonDocument.RootElement.TryGetProperty("response_format", out var responseFormatElement))
+                {
+                    responseFormat = responseFormatElement.GetString();
+                }
+
+                // Check if function_call is a string (direct function name)
+                if (functionCallElement.ValueKind == JsonValueKind.String)
+                {
+                    var functionName = functionCallElement.GetString();
+                    if (!string.IsNullOrEmpty(functionName))
+                    {
+                        var functionCall = OnnxFunction.ParseFunctionCall(functionName, "{}");
+                        return (functionCall, responseFormat);
+                    }
+                }
+
+                // Check if this is a natural language response (empty function_call)
+                if (functionCallElement.ValueKind == JsonValueKind.Object &&
+                    functionCallElement.EnumerateObject().Count() == 0)
+                {
+                    // Empty function_call means natural language response
+                    return (null, responseFormat);
+                }
+
+                // Check if this is an actual function call with name (arguments are optional)
+                if (functionCallElement.TryGetProperty("name", out var nameElement))
+                {
+                    var functionName = nameElement.GetString();
+                    
+                    if (!string.IsNullOrEmpty(functionName))
+                    {
+                        // Try to get arguments, use empty object if not present
+                        var argumentsJson = "{}";
+                        if (functionCallElement.TryGetProperty("arguments", out var argumentsElement))
+                        {
+                            argumentsJson = argumentsElement.GetRawText();
+                        }
+                        
+                        var functionCall = OnnxFunction.ParseFunctionCall(functionName, argumentsJson);
+                        return (functionCall, responseFormat);
+                    }
+                }
+            }
+        }
+        catch (JsonException)
+        {
+            // JSON parsing failed, return null to try other methods
+        }
+
+        return null;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Onnx/Internal/OnnxFunctionInvoker.cs
+++ b/dotnet/src/Connectors/Connectors.Onnx/Internal/OnnxFunctionInvoker.cs
@@ -1,0 +1,216 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace Microsoft.SemanticKernel.Connectors.Onnx.Internal;
+
+/// <summary>
+/// Handles invocation of functions and generation of natural language responses.
+/// </summary>
+internal sealed class OnnxFunctionInvoker
+{
+    private readonly ILogger _logger;
+    private readonly IChatCompletionService _chatCompletionService;
+
+    public OnnxFunctionInvoker(IChatCompletionService chatCompletionService, ILogger? logger = null)
+    {
+        this._chatCompletionService = chatCompletionService;
+        this._logger = logger ?? NullLogger.Instance;
+    }
+
+    /// <summary>
+    /// Invokes a function and generates a natural language response.
+    /// </summary>
+    public async Task<ChatMessageContent> InvokeFunctionAsync(
+        FunctionCallContent functionCall,
+        string? responseFormat,
+        OnnxToolCallingConfig toolCallingConfig,
+        ChatHistory chatHistory,
+        PromptExecutionSettings? executionSettings,
+        Kernel kernel,
+        CancellationToken cancellationToken)
+    {
+        this._logger.LogInformation("Manual fallback invoked for function: {FunctionName}", functionCall.FunctionName);
+
+        try
+        {
+            // Check if the function call is valid
+            if (!IsValidFunctionCall(functionCall, toolCallingConfig))
+            {
+                this._logger.LogWarning("Function call {FunctionName} is not in the allowed functions list", functionCall.FunctionName);
+                return new ChatMessageContent(AuthorRole.Assistant, "Function not available.");
+            }
+
+            // Try to find the function in the kernel
+            KernelFunction? function = FindFunction(functionCall, kernel);
+            if (function == null)
+            {
+                this._logger.LogWarning("Function {FunctionName} not found in any plugin", functionCall.FunctionName);
+                return new ChatMessageContent(AuthorRole.Assistant, "Function not found.");
+            }
+
+            // Invoke the function with the parsed arguments
+            this._logger.LogInformation("Manually invoking function {PluginName}.{FunctionName} with arguments: {Arguments}", 
+                function.PluginName, function.Name, 
+                functionCall.Arguments != null ? string.Join(", ", functionCall.Arguments.Select(kv => $"{kv.Key}={kv.Value}")) : "none");
+
+            var functionResult = await kernel.InvokeAsync(function, functionCall.Arguments, cancellationToken).ConfigureAwait(false);
+            var value = functionResult.GetValue<object>();
+            string resultValue = value?.ToString() ?? "<null>";
+
+            // Apply post-processing if response format is specified
+            string finalResult;
+            if (!string.IsNullOrEmpty(responseFormat))
+            {
+                this._logger.LogInformation("Applying response format: {ResponseFormat}", responseFormat);
+                finalResult = ApplyResponseFormat(responseFormat, resultValue);
+                this._logger.LogInformation("Applied response format. Original: {Original}, Final: {Final}", resultValue, finalResult);
+            }
+            else
+            {
+                // Return raw result - let the model handle natural language formatting like OpenAI does
+                finalResult = resultValue;
+            }
+
+            this._logger.LogInformation("Function {PluginName}.{FunctionName} returned: {Result}", function.PluginName, function.Name, resultValue);
+
+            // Generate natural language response
+            return await GenerateNaturalResponseAsync(functionCall, function, finalResult, chatHistory, executionSettings, kernel, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            this._logger.LogError(ex, "Manual function invocation failed for {FunctionName}", functionCall.FunctionName);
+            return new ChatMessageContent(AuthorRole.Assistant, "Error executing function.");
+        }
+    }
+
+    /// <summary>
+    /// Generates a natural language response based on the function result.
+    /// </summary>
+    private async Task<ChatMessageContent> GenerateNaturalResponseAsync(
+        FunctionCallContent functionCall,
+        KernelFunction function,
+        string finalResult,
+        ChatHistory chatHistory,
+        PromptExecutionSettings? executionSettings,
+        Kernel kernel,
+        CancellationToken cancellationToken)
+    {
+        // Implement OpenAI-style flow: pass the function result back to model for natural language generation
+        ChatHistory tempHistory = [];
+        
+        // Add a clear system message for natural response generation
+        tempHistory.AddSystemMessage("You are a helpful assistant. Answer the user's question directly and naturally based on the function result provided. Be concise and conversational.");
+        
+        // Get the original user question from the chat history
+        string originalQuestion = "";
+        foreach (ChatMessageContent message in chatHistory)
+        {
+            if (message.Role == AuthorRole.User)
+            {
+                originalQuestion = message.Content ?? "";
+            }
+        }
+        
+        // Structure the context more clearly for the model
+        tempHistory.AddUserMessage($"The user asked: \"{originalQuestion}\"");
+        tempHistory.AddAssistantMessage($"I'll check the {function.Name} function to answer that.");
+        tempHistory.Add(new ChatMessageContent(AuthorRole.Tool, $"Function {function.Name} returned: {finalResult}")
+        {
+            ModelId = functionCall.Id
+        });
+        tempHistory.AddUserMessage("Based on this function result, what is your answer to my original question?");
+
+        try
+        {
+            var naturalResponse = await this._chatCompletionService.GetChatMessageContentsAsync(tempHistory, executionSettings, kernel, cancellationToken).ConfigureAwait(false);
+            var response = naturalResponse.FirstOrDefault()?.Content ?? finalResult;
+            
+            this._logger.LogInformation("Model generated natural response: {Response}", response);
+            return new ChatMessageContent(AuthorRole.Assistant, response);
+        }
+        catch (Exception ex)
+        {
+            this._logger.LogError(ex, "Failed to generate natural language response, returning formatted result");
+            return new ChatMessageContent(AuthorRole.Assistant, OnnxResponseFormatter.FormatFunctionResult(function.Name, finalResult));
+        }
+    }
+
+    /// <summary>
+    /// Finds a function in the kernel by name.
+    /// </summary>
+    private KernelFunction? FindFunction(FunctionCallContent functionCall, Kernel kernel)
+    {
+        // First try with the provided plugin name
+        if (!string.IsNullOrEmpty(functionCall.PluginName))
+        {
+            var function = kernel.Plugins.GetFunction(functionCall.PluginName, functionCall.FunctionName);
+            if (function != null)
+            {
+                return function;
+            }
+        }
+        
+        // If not found, search across all plugins
+        foreach (var plugin in kernel.Plugins)
+        {
+            if (plugin.TryGetFunction(functionCall.FunctionName, out var function))
+            {
+                this._logger.LogInformation("Found function {FunctionName} in plugin {PluginName}", functionCall.FunctionName, plugin.Name);
+                return function;
+            }
+        }
+        
+        return null;
+    }
+
+    /// <summary>
+    /// Checks if a function call is valid (i.e., the function was advertised to the model).
+    /// </summary>
+    private static bool IsValidFunctionCall(FunctionCallContent functionCallContent, OnnxToolCallingConfig toolCallingConfig)
+    {
+        if (toolCallingConfig.AllowAnyRequestedKernelFunction)
+        {
+            return true;
+        }
+
+        if (toolCallingConfig.Tools is null)
+        {
+            return false;
+        }
+
+        return toolCallingConfig.Tools.Any(tool => tool.FunctionName == functionCallContent.FunctionName);
+    }
+
+    /// <summary>
+    /// Applies response format to the function result.
+    /// </summary>
+    private static string ApplyResponseFormat(string responseFormat, string functionResult)
+    {
+        try
+        {
+            // Replace {result} with the actual function result
+            var result = responseFormat.Replace("{result}", functionResult);
+
+            // If the response format doesn't contain {result}, it means the model provided a complete sentence
+            // Return it as-is (this is the versatile approach)
+            if (!responseFormat.Contains("{result}"))
+            {
+                return responseFormat;
+            }
+
+            return result;
+        }
+        catch (Exception)
+        {
+            // If any error occurs during formatting, return the original function result
+            return functionResult;
+        }
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Onnx/Internal/OnnxResponseFormatter.cs
+++ b/dotnet/src/Connectors/Connectors.Onnx/Internal/OnnxResponseFormatter.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.SemanticKernel.Connectors.Onnx.Internal;
+
+/// <summary>
+/// Handles formatting of function results for display.
+/// </summary>
+internal static class OnnxResponseFormatter
+{
+    /// <summary>
+    /// Formats function result for better user experience.
+    /// </summary>
+    public static string FormatFunctionResult(string functionName, string functionResult)
+    {
+        // Handle null/empty results (typically from void functions)
+        if (string.IsNullOrEmpty(functionResult) || functionResult == "<null>")
+        {
+            return "Done.";
+        }
+
+        // Handle boolean results more naturally
+        if (bool.TryParse(functionResult, out bool boolResult))
+        {
+            return boolResult ? "Yes." : "No.";
+        }
+
+        // Return the result as-is for all other cases
+        return functionResult;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Onnx/OnnxFunction.cs
+++ b/dotnet/src/Connectors/Connectors.Onnx/OnnxFunction.cs
@@ -1,0 +1,274 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace Microsoft.SemanticKernel.Connectors.Onnx;
+
+/// <summary>
+/// Represents a function that can be called by the ONNX model.
+/// </summary>
+[JsonConverter(typeof(OnnxFunctionJsonConverter))]
+public sealed class OnnxFunction
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OnnxFunction"/> class.
+    /// </summary>
+    /// <param name="functionName">The name of the function.</param>
+    /// <param name="description">The description of the function.</param>
+    /// <param name="parameters">The parameters of the function.</param>
+    /// <param name="returnParameter">The return parameter of the function.</param>
+    public OnnxFunction(string functionName, string description, IEnumerable<KernelParameterMetadata>? parameters = null, KernelReturnParameterMetadata? returnParameter = null)
+    {
+        Verify.NotNullOrWhiteSpace(functionName, nameof(functionName));
+        Verify.NotNullOrWhiteSpace(description, nameof(description));
+
+        this.FunctionName = functionName;
+        this.Description = description;
+        this.Parameters = parameters?.ToList() ?? [];
+        this.ReturnParameter = returnParameter;
+    }
+
+    /// <summary>
+    /// Gets the name of the function.
+    /// </summary>
+    public string FunctionName { get; }
+
+    /// <summary>
+    /// Gets the description of the function.
+    /// </summary>
+    public string Description { get; }
+
+    /// <summary>
+    /// Gets the parameters of the function.
+    /// </summary>
+    public IReadOnlyList<KernelParameterMetadata> Parameters { get; }
+
+    /// <summary>
+    /// Gets the return parameter of the function.
+    /// </summary>
+    public KernelReturnParameterMetadata? ReturnParameter { get; }
+
+    /// <summary>
+    /// Gets the JSON schema representation of the function.
+    /// </summary>
+    public JsonObject ToFunctionDefinition()
+    {
+        var functionDefinition = new JsonObject
+        {
+            ["name"] = this.FunctionName,
+            ["description"] = this.Description
+        };
+
+        if (this.Parameters.Count > 0)
+        {
+            var properties = new JsonObject();
+            var required = new JsonArray();
+
+            foreach (var parameter in this.Parameters)
+            {
+                var parameterSchema = GetParameterSchema(parameter);
+                properties[parameter.Name] = parameterSchema;
+
+                if (parameter.IsRequired)
+                {
+                    required.Add(parameter.Name);
+                }
+            }
+
+            functionDefinition["parameters"] = new JsonObject
+            {
+                ["type"] = "object",
+                ["properties"] = properties,
+                ["required"] = required
+            };
+        }
+
+        return functionDefinition;
+    }
+
+    /// <summary>
+    /// Gets the JSON schema for a parameter.
+    /// </summary>
+    private static JsonObject GetParameterSchema(KernelParameterMetadata parameter)
+    {
+        var schema = new JsonObject();
+
+        // Set type based on parameter type
+        var type = parameter.ParameterType;
+        if (type == typeof(string))
+        {
+            schema["type"] = "string";
+        }
+        else if (type == typeof(int) || type == typeof(int?))
+        {
+            schema["type"] = "integer";
+        }
+        else if (type == typeof(double) || type == typeof(float) || type == typeof(double?) || type == typeof(float?))
+        {
+            schema["type"] = "number";
+        }
+        else if (type == typeof(bool) || type == typeof(bool?))
+        {
+            schema["type"] = "boolean";
+        }
+        else if (type.IsArray || (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(List<>)))
+        {
+            schema["type"] = "array";
+        }
+        else
+        {
+            schema["type"] = "object";
+        }
+
+        // Add description if available
+        if (!string.IsNullOrEmpty(parameter.Description))
+        {
+            schema["description"] = parameter.Description;
+        }
+
+        // Add default value if available
+        if (parameter.DefaultValue is not null)
+        {
+            schema["default"] = JsonSerializer.SerializeToNode(parameter.DefaultValue);
+        }
+
+        return schema;
+    }
+
+    /// <summary>
+    /// Parses a function call from the model's response.
+    /// </summary>
+    /// <param name="functionName">The name of the function called.</param>
+    /// <param name="argumentsJson">The JSON string containing the function arguments.</param>
+    /// <returns>A <see cref="FunctionCallContent"/> representing the function call.</returns>
+    public static FunctionCallContent ParseFunctionCall(string functionName, string argumentsJson)
+    {
+        var arguments = new KernelArguments();
+
+        if (!string.IsNullOrEmpty(argumentsJson))
+        {
+            try
+            {
+                var jsonDocument = JsonDocument.Parse(argumentsJson);
+                foreach (var property in jsonDocument.RootElement.EnumerateObject())
+                {
+                    arguments[property.Name] = property.Value.GetRawText();
+                }
+            }
+            catch (JsonException)
+            {
+                // If parsing fails, treat the entire string as a single argument
+                arguments["input"] = argumentsJson;
+            }
+        }
+
+        return new FunctionCallContent(functionName, arguments);
+    }
+
+    /// <summary>
+    /// Creates a function result content from the function result.
+    /// </summary>
+    /// <param name="functionCallContent">The function call content.</param>
+    /// <param name="result">The result of the function call.</param>
+    /// <returns>A <see cref="FunctionResultContent"/> representing the function result.</returns>
+    public static FunctionResultContent CreateFunctionResult(FunctionCallContent functionCallContent, object? result)
+    {
+        var resultString = result switch
+        {
+            string s => s,
+            null => "null",
+            _ => JsonSerializer.Serialize(result)
+        };
+
+        return new FunctionResultContent(functionCallContent, resultString);
+    }
+}
+
+/// <summary>
+/// JSON converter for <see cref="OnnxFunction"/>.
+/// </summary>
+public sealed class OnnxFunctionJsonConverter : JsonConverter<OnnxFunction>
+{
+    /// <inheritdoc/>
+    public override OnnxFunction? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+        {
+            throw new JsonException("Expected start of object.");
+        }
+
+        string? functionName = null;
+        string? description = null;
+        List<KernelParameterMetadata>? parameters = null;
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                break;
+            }
+
+            if (reader.TokenType == JsonTokenType.PropertyName)
+            {
+                string propertyName = reader.GetString()!;
+                reader.Read();
+
+                switch (propertyName)
+                {
+                    case "name":
+                        functionName = reader.GetString();
+                        break;
+                    case "description":
+                        description = reader.GetString();
+                        break;
+                    case "parameters":
+                        // For simplicity, we'll skip parsing parameters in the JSON converter
+                        // In a real implementation, you might want to parse these
+                        reader.Skip();
+                        break;
+                }
+            }
+        }
+
+        if (functionName is null || description is null)
+        {
+            throw new JsonException("Missing required properties.");
+        }
+
+        return new OnnxFunction(functionName, description, parameters);
+    }
+
+    /// <inheritdoc/>
+    public override void Write(Utf8JsonWriter writer, OnnxFunction value, JsonSerializerOptions options)
+    {
+        var functionDefinition = value.ToFunctionDefinition();
+        functionDefinition.WriteTo(writer);
+    }
+}
+
+/// <summary>
+/// Extension methods for <see cref="KernelFunctionMetadata"/> to convert to <see cref="OnnxFunction"/>.
+/// </summary>
+public static class OnnxFunctionExtensions
+{
+    /// <summary>
+    /// Converts a <see cref="KernelFunctionMetadata"/> to an <see cref="OnnxFunction"/>.
+    /// </summary>
+    /// <param name="metadata">The function metadata.</param>
+    /// <returns>An <see cref="OnnxFunction"/> representation of the metadata.</returns>
+    public static OnnxFunction ToOnnxFunction(this KernelFunctionMetadata metadata)
+    {
+        return new OnnxFunction(
+            functionName: metadata.Name,
+            description: metadata.Description,
+            parameters: metadata.Parameters,
+            returnParameter: metadata.ReturnParameter);
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Onnx/OnnxFunction.cs
+++ b/dotnet/src/Connectors/Connectors.Onnx/OnnxFunction.cs
@@ -56,6 +56,16 @@ public sealed class OnnxFunction
     public KernelReturnParameterMetadata? ReturnParameter { get; }
 
     /// <summary>
+    /// Gets the name of the function (for compatibility with KernelFunction).
+    /// </summary>
+    public string Name => this.FunctionName;
+
+    /// <summary>
+    /// Gets the plugin name (for compatibility; ONNX functions do not have plugins).
+    /// </summary>
+    public string? PluginName => null;
+
+    /// <summary>
     /// Gets the JSON schema representation of the function.
     /// </summary>
     public JsonObject ToFunctionDefinition()
@@ -169,7 +179,7 @@ public sealed class OnnxFunction
             }
         }
 
-        return new FunctionCallContent(functionName, arguments);
+        return new FunctionCallContent(functionName, arguments: arguments);
     }
 
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Onnx/OnnxFunction.cs
+++ b/dotnet/src/Connectors/Connectors.Onnx/OnnxFunction.cs
@@ -169,7 +169,16 @@ public sealed class OnnxFunction
                 var jsonDocument = JsonDocument.Parse(argumentsJson);
                 foreach (var property in jsonDocument.RootElement.EnumerateObject())
                 {
-                    arguments[property.Name] = property.Value.GetRawText();
+                    // Parse the actual value instead of raw text
+                    arguments[property.Name] = property.Value.ValueKind switch
+                    {
+                        JsonValueKind.String => property.Value.GetString(),
+                        JsonValueKind.Number => property.Value.TryGetInt32(out int intValue) ? intValue : property.Value.GetDouble(),
+                        JsonValueKind.True => true,
+                        JsonValueKind.False => false,
+                        JsonValueKind.Null => null,
+                        _ => property.Value.GetRawText()
+                    };
                 }
             }
             catch (JsonException)

--- a/dotnet/src/Connectors/Connectors.Onnx/OnnxKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Onnx/OnnxKernelBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 
 using System;
 using System.IO;
@@ -35,6 +35,36 @@ public static class OnnxKernelBuilderExtensions
     {
         builder.Services.AddKeyedSingleton<IChatCompletionService>(serviceId, (serviceProvider, _) =>
             new OnnxRuntimeGenAIChatCompletionService(
+                modelId,
+                modelPath: modelPath,
+                loggerFactory: serviceProvider.GetService<ILoggerFactory>(),
+                jsonSerializerOptions));
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds the ONNX GenAI chat completion service with function calling support to the <see cref="IKernelBuilder"/>.
+    /// </summary>
+    /// <param name="builder">The <see cref="IKernelBuilder"/> instance to augment.</param>
+    /// <param name="modelId">The name of the model.</param>
+    /// <param name="modelPath">The generative AI ONNX model path for the chat completion service.</param>
+    /// <param name="serviceId">A local identifier for the given AI service.</param>
+    /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for various aspects of serialization, such as function argument deserialization, function result serialization, logging, etc., of the service.</param>
+    /// <returns>The same instance as <paramref name="builder"/>.</returns>
+    public static IKernelBuilder AddOnnxRuntimeGenAIFunctionCallingChatCompletion(
+        this IKernelBuilder builder,
+        string modelId,
+        string modelPath,
+        string? serviceId = null,
+        JsonSerializerOptions? jsonSerializerOptions = null)
+    {
+        Verify.NotNull(builder);
+        Verify.NotNullOrWhiteSpace(modelId);
+        Verify.NotNullOrWhiteSpace(modelPath);
+
+        builder.Services.AddKeyedSingleton<IChatCompletionService>(serviceId, (serviceProvider, _) =>
+            new OnnxRuntimeGenAIFunctionCallingChatCompletionService(
                 modelId,
                 modelPath: modelPath,
                 loggerFactory: serviceProvider.GetService<ILoggerFactory>(),

--- a/dotnet/src/Connectors/Connectors.Onnx/OnnxKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Onnx/OnnxKernelBuilderExtensions.cs
@@ -1,6 +1,7 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using Microsoft.Extensions.AI;
@@ -51,13 +52,15 @@ public static class OnnxKernelBuilderExtensions
     /// <param name="modelPath">The generative AI ONNX model path for the chat completion service.</param>
     /// <param name="serviceId">A local identifier for the given AI service.</param>
     /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for various aspects of serialization, such as function argument deserialization, function result serialization, logging, etc., of the service.</param>
+    /// <param name="providers">The providers to use for the chat completion service.</param>
     /// <returns>The same instance as <paramref name="builder"/>.</returns>
     public static IKernelBuilder AddOnnxRuntimeGenAIFunctionCallingChatCompletion(
         this IKernelBuilder builder,
         string modelId,
         string modelPath,
         string? serviceId = null,
-        JsonSerializerOptions? jsonSerializerOptions = null)
+        JsonSerializerOptions? jsonSerializerOptions = null,
+        List<string>? providers = null)
     {
         Verify.NotNull(builder);
         Verify.NotNullOrWhiteSpace(modelId);
@@ -68,7 +71,8 @@ public static class OnnxKernelBuilderExtensions
                 modelId,
                 modelPath: modelPath,
                 loggerFactory: serviceProvider.GetService<ILoggerFactory>(),
-                jsonSerializerOptions));
+                jsonSerializerOptions,
+                providers));
 
         return builder;
     }

--- a/dotnet/src/Connectors/Connectors.Onnx/OnnxKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Onnx/OnnxKernelBuilderExtensions.cs
@@ -19,60 +19,77 @@ namespace Microsoft.SemanticKernel;
 public static class OnnxKernelBuilderExtensions
 {
     /// <summary>
-    /// Add OnnxRuntimeGenAI Chat Completion services to the kernel builder.
+    /// Adds the OnnxRuntimeGenAI Chat Completion services to the specified <see cref="IKernelBuilder"/>.
     /// </summary>
-    /// <param name="builder">The kernel builder.</param>
+    /// <param name="builder">The <see cref="IKernelBuilder"/> instance to augment.</param>
+    /// <param name="modelPath">The generative AI ONNX model path for the chat completion service.</param>
+    /// <param name="serviceId">A local identifier for the given AI service.</param>
     /// <param name="modelId">Model Id.</param>
-    /// <param name="modelPath">The generative AI ONNX model path.</param>
-    /// <param name="serviceId">The optional service ID.</param>
+    /// <param name="loggerFactory">Logger factory.</param>
     /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for various aspects of serialization, such as function argument deserialization, function result serialization, logging, etc., of the service.</param>
-    /// <returns>The updated kernel builder.</returns>
+    /// <param name="providers">Providers</param>
+    /// <returns>The same instance as <paramref name="builder"/>.</returns>
     public static IKernelBuilder AddOnnxRuntimeGenAIChatCompletion(
         this IKernelBuilder builder,
-        string modelId,
         string modelPath,
-        string? serviceId = null,
-        JsonSerializerOptions? jsonSerializerOptions = null)
+        string serviceId,
+        string? modelId = null,
+        ILoggerFactory? loggerFactory = null,
+        JsonSerializerOptions? jsonSerializerOptions = null,
+        List<string>? providers = null
+    )
     {
-        builder.Services.AddKeyedSingleton<IChatCompletionService>(serviceId, (serviceProvider, _) =>
+        Verify.NotNull(builder);
+        Verify.NotNullOrWhiteSpace(modelPath);
+        Verify.NotNullOrWhiteSpace(serviceId);
+
+        builder.Services.AddKeyedSingleton<IChatCompletionService>(serviceId, (_, _) =>
             new OnnxRuntimeGenAIChatCompletionService(
-                modelId,
                 modelPath: modelPath,
-                loggerFactory: serviceProvider.GetService<ILoggerFactory>(),
-                jsonSerializerOptions));
+                modelId: modelId,
+                loggerFactory: loggerFactory,
+                jsonSerializerOptions: jsonSerializerOptions,
+                providers: providers
+            )
+        );
 
         return builder;
     }
 
     /// <summary>
-    /// Adds the ONNX GenAI chat completion service with function calling support to the <see cref="IKernelBuilder"/>.
+    /// Adds the OnnxRuntimeGenAI Chat Completion services with function calling support to the <see cref="IKernelBuilder"/>.
     /// </summary>
     /// <param name="builder">The <see cref="IKernelBuilder"/> instance to augment.</param>
-    /// <param name="modelId">The name of the model.</param>
     /// <param name="modelPath">The generative AI ONNX model path for the chat completion service.</param>
     /// <param name="serviceId">A local identifier for the given AI service.</param>
+    /// <param name="modelId">Model Id.</param>
+    /// <param name="loggerFactory">Logger factory.</param>
     /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for various aspects of serialization, such as function argument deserialization, function result serialization, logging, etc., of the service.</param>
-    /// <param name="providers">The providers to use for the chat completion service.</param>
+    /// <param name="providers">Providers</param>
     /// <returns>The same instance as <paramref name="builder"/>.</returns>
     public static IKernelBuilder AddOnnxRuntimeGenAIFunctionCallingChatCompletion(
         this IKernelBuilder builder,
-        string modelId,
         string modelPath,
-        string? serviceId = null,
+        string serviceId,
+        string? modelId = null,
+        ILoggerFactory? loggerFactory = null,
         JsonSerializerOptions? jsonSerializerOptions = null,
-        List<string>? providers = null)
+        List<string>? providers = null
+    )
     {
         Verify.NotNull(builder);
-        Verify.NotNullOrWhiteSpace(modelId);
         Verify.NotNullOrWhiteSpace(modelPath);
+        Verify.NotNullOrWhiteSpace(serviceId);
 
-        builder.Services.AddKeyedSingleton<IChatCompletionService>(serviceId, (serviceProvider, _) =>
+        builder.Services.AddKeyedSingleton<IChatCompletionService>(serviceId, (_, _) =>
             new OnnxRuntimeGenAIFunctionCallingChatCompletionService(
-                modelId,
                 modelPath: modelPath,
-                loggerFactory: serviceProvider.GetService<ILoggerFactory>(),
-                jsonSerializerOptions,
-                providers));
+                modelId: modelId,
+                loggerFactory: loggerFactory,
+                jsonSerializerOptions: jsonSerializerOptions,
+                providers: providers
+            )
+        );
 
         return builder;
     }

--- a/dotnet/src/Connectors/Connectors.Onnx/OnnxRuntimeGenAIChatCompletionService.cs
+++ b/dotnet/src/Connectors/Connectors.Onnx/OnnxRuntimeGenAIChatCompletionService.cs
@@ -18,7 +18,8 @@ namespace Microsoft.SemanticKernel.Connectors.Onnx;
 /// </summary>
 public sealed class OnnxRuntimeGenAIChatCompletionService : IChatCompletionService, IDisposable
 {
-    private readonly string _modelPath;
+    private readonly Config _config;
+    private readonly Model _model;
     private OnnxRuntimeGenAIChatClient? _chatClient;
     private IChatCompletionService? _chatClientWrapper;
     private readonly Dictionary<string, object?> _attributesInternal = [];
@@ -29,26 +30,36 @@ public sealed class OnnxRuntimeGenAIChatCompletionService : IChatCompletionServi
     /// <summary>
     /// Initializes a new instance of the OnnxRuntimeGenAIChatCompletionService class.
     /// </summary>
-    /// <param name="modelId">The name of the model.</param>
     /// <param name="modelPath">The generative AI ONNX model path for the chat completion service.</param>
+    /// <param name="modelId">The name of the model.</param>
     /// <param name="loggerFactory">Optional logger factory to be used for logging.</param>
     /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for various aspects of serialization and deserialization required by the service.</param>
+    /// <param name="providers">The providers to use for the chat completion service.</param>
     public OnnxRuntimeGenAIChatCompletionService(
-        string modelId,
         string modelPath,
+        string? modelId = null,
         ILoggerFactory? loggerFactory = null,
-        JsonSerializerOptions? jsonSerializerOptions = null)
+        JsonSerializerOptions? jsonSerializerOptions = null,
+        List<string>? providers = null)
     {
-        Verify.NotNullOrWhiteSpace(modelId);
         Verify.NotNullOrWhiteSpace(modelPath);
-
         this._attributesInternal.Add(AIServiceExtensions.ModelIdKey, modelId);
-        this._modelPath = modelPath;
+        this._config = new Config(modelPath);
+        if (providers != null)
+        {
+            this._config.ClearProviders();
+            foreach (string provider in providers)
+            {
+                this._config.AppendProvider(provider);
+            }
+        }
+
+        this._model = new Model(this._config);
     }
 
     private IChatCompletionService GetChatCompletionService()
     {
-        this._chatClient ??= new OnnxRuntimeGenAIChatClient(this._modelPath, new OnnxRuntimeGenAIChatClientOptions()
+        this._chatClient ??= new OnnxRuntimeGenAIChatClient(this._model, false, new OnnxRuntimeGenAIChatClientOptions()
         {
             PromptFormatter = (messages, options) =>
             {
@@ -57,6 +68,7 @@ public sealed class OnnxRuntimeGenAIChatCompletionService : IChatCompletionServi
                 {
                     promptBuilder.Append($"<|{message.Role}|>\n{message.Text}");
                 }
+
                 promptBuilder.Append("<|end|>\n<|assistant|>");
 
                 return promptBuilder.ToString();
@@ -67,7 +79,12 @@ public sealed class OnnxRuntimeGenAIChatCompletionService : IChatCompletionServi
     }
 
     /// <inheritdoc/>
-    public void Dispose() => this._chatClient?.Dispose();
+    public void Dispose()
+    {
+        this._model.Dispose();
+        this._config.Dispose();
+        this._chatClient?.Dispose();
+    }
 
     /// <inheritdoc/>
     public Task<IReadOnlyList<ChatMessageContent>> GetChatMessageContentsAsync(ChatHistory chatHistory, PromptExecutionSettings? executionSettings = null, Kernel? kernel = null, CancellationToken cancellationToken = default) =>

--- a/dotnet/src/Connectors/Connectors.Onnx/OnnxRuntimeGenAIFunctionCallingChatCompletionService.cs
+++ b/dotnet/src/Connectors/Connectors.Onnx/OnnxRuntimeGenAIFunctionCallingChatCompletionService.cs
@@ -8,7 +8,6 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization.Metadata;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -16,6 +15,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.ML.OnnxRuntimeGenAI;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.FunctionCalling;
+using Microsoft.SemanticKernel.Connectors.Onnx.Internal;
 using Microsoft.SemanticKernel.Services;
 
 namespace Microsoft.SemanticKernel.Connectors.Onnx;
@@ -29,6 +29,8 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
     private readonly Model _model;
     private readonly ILogger _logger;
     private readonly FunctionCallsProcessor _functionCallsProcessor;
+    private readonly OnnxFunctionCallParser _functionCallParser;
+    private OnnxFunctionInvoker? _functionInvoker;
     private OnnxRuntimeGenAIChatClient? _chatClient;
     private IChatCompletionService? _chatClientWrapper;
     private readonly Dictionary<string, object?> _attributesInternal = [];
@@ -67,8 +69,7 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
 
         this._logger = loggerFactory?.CreateLogger<OnnxRuntimeGenAIFunctionCallingChatCompletionService>() ?? NullLogger<OnnxRuntimeGenAIFunctionCallingChatCompletionService>.Instance;
         this._functionCallsProcessor = new FunctionCallsProcessor(this._logger);
-
-        this._logger.LogInformation("OnnxRuntimeGenAIFunctionCallingChatCompletionService initialized with model: {ModelId} at path: {ModelPath}", modelId, modelPath);
+        this._functionCallParser = new OnnxFunctionCallParser(this._logger);
     }
 
     private IChatCompletionService GetChatCompletionService()
@@ -89,43 +90,7 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
             }
         });
 
-        // Return a wrapper that handles the basic chat completion without function calling
-        return this._chatClientWrapper ??= new BasicOnnxChatCompletionService(this._chatClient);
-    }
-
-    /// <summary>
-    /// Basic chat completion service wrapper that doesn't handle function calling.
-    /// </summary>
-    private sealed class BasicOnnxChatCompletionService : IChatCompletionService
-    {
-        private readonly OnnxRuntimeGenAIChatClient _chatClient;
-        private readonly IChatCompletionService _wrappedService;
-
-        public BasicOnnxChatCompletionService(OnnxRuntimeGenAIChatClient chatClient)
-        {
-            this._chatClient = chatClient;
-            this._wrappedService = chatClient.AsChatCompletionService();
-        }
-
-        public IReadOnlyDictionary<string, object?> Attributes => this._wrappedService.Attributes;
-
-        public Task<IReadOnlyList<ChatMessageContent>> GetChatMessageContentsAsync(
-            ChatHistory chatHistory,
-            PromptExecutionSettings? executionSettings = null,
-            Kernel? kernel = null,
-            CancellationToken cancellationToken = default)
-        {
-            return this._wrappedService.GetChatMessageContentsAsync(chatHistory, executionSettings, kernel, cancellationToken);
-        }
-
-        public IAsyncEnumerable<StreamingChatMessageContent> GetStreamingChatMessageContentsAsync(
-            ChatHistory chatHistory,
-            PromptExecutionSettings? executionSettings = null,
-            Kernel? kernel = null,
-            CancellationToken cancellationToken = default)
-        {
-            return this._wrappedService.GetStreamingChatMessageContentsAsync(chatHistory, executionSettings, kernel, cancellationToken);
-        }
+        return this._chatClientWrapper ??= this._chatClient.AsChatCompletionService();
     }
 
     /// <inheritdoc/>
@@ -141,59 +106,24 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
         ChatHistory chatHistory,
         PromptExecutionSettings? executionSettings = null,
         Kernel? kernel = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default
+    )
     {
-        this._logger.LogInformation("GetChatMessageContentsAsync called");
+        OnnxRuntimeGenAIPromptExecutionSettings onnxExecutionSettings = GetOnnxExecutionSettings(executionSettings);
 
-        var onnxExecutionSettings = GetOnnxExecutionSettings(executionSettings);
-        this._logger.LogInformation("ONNX execution settings: {Settings}", onnxExecutionSettings.FunctionChoiceBehavior?.GetType().Name ?? "null");
-
-        var toolCallingConfig = this.GetToolCallingConfig(onnxExecutionSettings, kernel, chatHistory, 0);
-
-        this._logger.LogInformation("Tool calling config: {Config}", toolCallingConfig != null ? "configured" : "null");
-        if (toolCallingConfig != null)
+        OnnxToolCallingConfig? toolCallingConfig = this.GetToolCallingConfig(onnxExecutionSettings, kernel, chatHistory, 0);
+        if (toolCallingConfig?.Tools is null || toolCallingConfig.Tools.Count == 0)
         {
-            this._logger.LogInformation("Tools count: {Count}, AutoInvoke: {AutoInvoke}", toolCallingConfig.Tools?.Count ?? 0, toolCallingConfig.AutoInvoke);
-        }
-
-        // If no function calling is configured, use the base service
-        if (toolCallingConfig is null || toolCallingConfig.Tools is null || toolCallingConfig.Tools.Count == 0)
-        {
-            this._logger.LogInformation("No function calling configured, using base service");
             return await this.GetChatCompletionService().GetChatMessageContentsAsync(chatHistory, executionSettings, kernel, cancellationToken).ConfigureAwait(false);
         }
 
-        this._logger.LogInformation("Function calling is configured, processing with function calling");
-
         // Create a modified chat history with function definitions
-        var modifiedChatHistory = await this.CreateModifiedChatHistoryAsync(chatHistory, toolCallingConfig, cancellationToken).ConfigureAwait(false);
+        ChatHistory modifiedChatHistory = await this.CreateModifiedChatHistoryAsync(chatHistory, toolCallingConfig, cancellationToken).ConfigureAwait(false);
 
         // Get the response from the underlying service
-        var results = await this.GetChatCompletionService().GetChatMessageContentsAsync(modifiedChatHistory, executionSettings, kernel, cancellationToken).ConfigureAwait(false);
+        IReadOnlyList<ChatMessageContent> results = await this.GetChatCompletionService().GetChatMessageContentsAsync(modifiedChatHistory, executionSettings, kernel, cancellationToken).ConfigureAwait(false);
 
-        this._logger.LogInformation("Got {Count} results from base service", results.Count);
-        foreach (var result in results)
-        {
-            this._logger.LogInformation("Result content: {Content}", result.Content);
-        }
-
-        // Process the results for function calls
-        ChatMessageContent? first = null;
-        foreach (ChatMessageContent result in results)
-        {
-            first = result;
-            break;
-        }
-
-        this._logger.LogInformation("About to process results for function calls. Raw result content: {Content}", first?.Content);
-        var processedResults = await this.ProcessChatMessageContentsAsync(results, toolCallingConfig, chatHistory, 0, executionSettings, kernel, cancellationToken).ConfigureAwait(false);
-
-        this._logger.LogInformation("Processed {Count} results", processedResults.Count);
-        foreach (var result in processedResults)
-        {
-            this._logger.LogInformation("Processed result content: {Content}", result.Content);
-        }
-
+        IReadOnlyList<ChatMessageContent> processedResults = await this.ProcessChatMessageContentsAsync(results, toolCallingConfig, chatHistory, 0, executionSettings, kernel, cancellationToken).ConfigureAwait(false);
         return processedResults;
     }
 
@@ -234,7 +164,7 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
 
             // Check if we have a complete function call
             var currentResponse = responseBuilder.ToString();
-            if (!hasFunctionCall && ContainsFunctionCall(currentResponse))
+            if (!hasFunctionCall && this._functionCallParser.ContainsFunctionCall(currentResponse))
             {
                 hasFunctionCall = true;
                 this._logger.LogInformation("Detected function call in streaming response");
@@ -344,8 +274,20 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
         if (toolCallingConfig.Tools is not null && toolCallingConfig.Tools.Count > 0)
         {
             var functionsJson = CreateFunctionsJson(toolCallingConfig.Tools);
-            var systemMessage =
-                $"You are a helpful assistant with access to the following functions:\n\n{functionsJson}\n\nIMPORTANT: You MUST use these functions when the user's request relates to them. Do NOT provide general responses when a function is available.\n\nFor ANY user question that can be answered by calling a function, respond with raw JSON (no markdown formatting):\n{{\"function_call\": {{\"name\": \"function_name\", \"arguments\": {{\"param1\": \"value1\"}}}}}}\n\nFor natural language responses after function results, respond with JSON:\n{{\"function_call\": {{}}, \"response_format\": \"your response here\"}}\n\nReturn only the JSON object, without code blocks or markdown formatting. ALWAYS call the relevant function first. NEVER give general explanations when a function can handle the request.";
+            var systemMessage = "You are a helpful assistant with access to the following functions:"
+                                + functionsJson +
+                                """
+
+                                IMPORTANT: You MUST use these functions when the user's request relates to them. Do NOT provide general responses when a function is available.
+
+                                For ANY user question that can be answered by calling a function, respond with raw JSON (no markdown formatting):
+                                {"function_call": {"name": "function_name", "arguments": {"param1": "value1"}}}
+
+                                For natural language responses after function results, respond with JSON:
+                                {"function_call": {}, "response_format": "your response here"}
+
+                                Return only the JSON object, without code blocks or markdown formatting. ALWAYS call the relevant function first. NEVER give general explanations when a function can handle the request.
+                                """;
 
             modifiedChatHistory.AddSystemMessage(systemMessage);
         }
@@ -426,14 +368,14 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
         }
 
         // Quick pre-check: if content doesn't contain function call patterns, skip parsing
-        if (!ContainsFunctionCall(result.Content))
+        if (!this._functionCallParser.ContainsFunctionCall(result.Content))
         {
             this._logger.LogDebug("Content does not contain function call patterns, skipping parsing");
             return result;
         }
 
         // Try to parse function call from the response
-        var parseResult = TryParseFunctionCallWithResponse(result.Content);
+        var parseResult = this._functionCallParser.TryParseFunctionCallWithResponse(result.Content);
         if (parseResult is null)
         {
             return result;
@@ -473,7 +415,7 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
             this._logger.LogInformation("Standard processing returned message: {Content}", lastMessage?.Content ?? "null");
 
             // Check if the standard processing actually replaced the JSON content
-            if (lastMessage != null && !ContainsFunctionCall(lastMessage.Content))
+            if (lastMessage != null && !this._functionCallParser.ContainsFunctionCall(lastMessage.Content))
             {
                 this._logger.LogInformation("Standard function call processing succeeded, content replaced");
                 return lastMessage;
@@ -490,381 +432,8 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
 
         // Fallback: Manual function invocation if standard processing fails or returns JSON
         this._logger.LogInformation("Using manual fallback for function call");
-        return await TryManualFunctionInvocationAsync(result, functionCall, responseFormat, toolCallingConfig, chatHistory, requestIndex, executionSettings, kernel, cancellationToken).ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Manual fallback for function invocation when standard processing fails.
-    /// </summary>
-    private async Task<ChatMessageContent> TryManualFunctionInvocationAsync(
-        ChatMessageContent result,
-        FunctionCallContent functionCall,
-        OnnxToolCallingConfig toolCallingConfig,
-        ChatHistory chatHistory,
-        int requestIndex,
-        PromptExecutionSettings? executionSettings,
-        Kernel kernel,
-        CancellationToken cancellationToken)
-    {
-        return await TryManualFunctionInvocationAsync(result, functionCall, null, toolCallingConfig, chatHistory, requestIndex, executionSettings, kernel, cancellationToken).ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Manual fallback for function invocation when standard processing fails.
-    /// </summary>
-    private async Task<ChatMessageContent> TryManualFunctionInvocationAsync(
-        ChatMessageContent result,
-        FunctionCallContent functionCall,
-        string? responseFormat,
-        OnnxToolCallingConfig toolCallingConfig,
-        ChatHistory chatHistory,
-        int requestIndex,
-        PromptExecutionSettings? executionSettings,
-        Kernel kernel,
-        CancellationToken cancellationToken)
-    {
-        this._logger.LogInformation("Manual fallback invoked for function: {FunctionName}", functionCall.FunctionName);
-
-        try
-        {
-            // Check if the function call is valid
-            if (!IsValidFunctionCall(functionCall, toolCallingConfig))
-            {
-                this._logger.LogWarning("Function call {FunctionName} is not in the allowed functions list", functionCall.FunctionName);
-                return result;
-            }
-
-            // Try to find the function in the kernel
-            KernelFunction? function = null;
-
-            // First try with the provided plugin name
-            if (!string.IsNullOrEmpty(functionCall.PluginName))
-            {
-                function = kernel.Plugins.GetFunction(functionCall.PluginName, functionCall.FunctionName);
-            }
-
-            // If not found, search across all plugins
-            if (function == null)
-            {
-                foreach (var plugin in kernel.Plugins)
-                {
-                    if (plugin.TryGetFunction(functionCall.FunctionName, out function))
-                    {
-                        this._logger.LogInformation("Found function {FunctionName} in plugin {PluginName}", functionCall.FunctionName, plugin.Name);
-                        break;
-                    }
-                }
-            }
-
-            if (function == null)
-            {
-                this._logger.LogWarning("Function {FunctionName} not found in any plugin", functionCall.FunctionName);
-                return result;
-            }
-
-            // Invoke the function with the parsed arguments
-            this._logger.LogInformation("Manually invoking function {PluginName}.{FunctionName} with arguments: {Arguments}", function.PluginName, function.Name, functionCall.Arguments != null ? string.Join(", ", functionCall.Arguments.Select(kv => $"{kv.Key}={kv.Value}")) : "none");
-
-            var functionResult = await kernel.InvokeAsync(function, functionCall.Arguments, cancellationToken).ConfigureAwait(false);
-            var value = functionResult.GetValue<object>();
-            string resultValue = value?.ToString() ?? "<null>";
-
-            // Apply post-processing if response format is specified
-            string finalResult;
-            if (!string.IsNullOrEmpty(responseFormat))
-            {
-                this._logger.LogInformation("Applying response format: {ResponseFormat}", responseFormat);
-                finalResult = ApplyResponseFormat(responseFormat, resultValue);
-                this._logger.LogInformation("Applied response format. Original: {Original}, Final: {Final}", resultValue, finalResult);
-            }
-            else
-            {
-                // Return raw result - let the model handle natural language formatting like OpenAI does
-                finalResult = resultValue;
-            }
-
-            this._logger.LogInformation("Function {PluginName}.{FunctionName} returned: {Result}", function.PluginName, function.Name, resultValue);
-
-            // Implement OpenAI-style flow: pass the function result back to model for natural language generation
-            ChatHistory tempHistory = [];
-            foreach (ChatMessageContent message in chatHistory)
-            {
-                tempHistory.Add(message);
-            }
-
-            // Add the function call result as a tool message
-            tempHistory.Add(new ChatMessageContent(AuthorRole.Tool, $"Function {function.Name} returned: {finalResult}")
-            {
-                ModelId = functionCall.Id
-            });
-
-            // Ask the model to respond directly to the original user question using the function result
-            tempHistory.AddSystemMessage("Answer the user's original question directly and naturally using the function result.");
-
-            try
-            {
-                IReadOnlyList<ChatMessageContent> naturalResponse = await this.GetChatCompletionService().GetChatMessageContentsAsync(tempHistory, executionSettings, kernel, cancellationToken).ConfigureAwait(false);
-                string response = naturalResponse.FirstOrDefault()?.Content ?? finalResult;
-
-                this._logger.LogInformation("Model generated natural response: {Response}", response);
-                return new ChatMessageContent(AuthorRole.Assistant, response);
-            }
-            catch (Exception ex)
-            {
-                this._logger.LogError(ex, "Failed to generate natural language response, returning formatted result");
-                return new ChatMessageContent(AuthorRole.Assistant, FormatFunctionResult(function.Name, resultValue));
-            }
-        }
-        catch (Exception ex)
-        {
-            this._logger.LogError(ex, "Manual function invocation failed for {FunctionName}", functionCall.FunctionName);
-            return result;
-        }
-    }
-
-    /// <summary>
-    /// Tries to parse a function call from the model's response.
-    /// </summary>
-    private (FunctionCallContent? FunctionCall, string? ResponseFormat)? TryParseFunctionCallWithResponse(string? content)
-    {
-        if (string.IsNullOrEmpty(content))
-        {
-            return null;
-        }
-
-        this._logger.LogInformation("Attempting to parse function call from content: {Content}", content);
-
-        // First, try to parse the entire content as pure JSON with response format
-        var resultFromContent = TryParseJsonFunctionCallWithResponse(content.Trim());
-        if (resultFromContent != null)
-        {
-            this._logger.LogInformation("Successfully parsed function call from pure JSON content: {FunctionName}", resultFromContent.Value.FunctionCall?.FunctionName);
-            return resultFromContent;
-        }
-
-        // --- Robustness: Try to fix missing closing brace ---
-        var trimmed = content.Trim();
-        if (trimmed.StartsWith("{") && trimmed.Contains("function_call") && !trimmed.EndsWith("}"))
-        {
-            var fixedJson = trimmed + "}";
-            var fixedResult = TryParseJsonFunctionCallWithResponse(fixedJson);
-            if (fixedResult != null)
-            {
-                this._logger.LogInformation("Successfully parsed function call from auto-corrected JSON (added closing brace)");
-                return fixedResult;
-            }
-        }
-        // -----------------------------------------------------
-
-        // Try to extract JSON from the first line and natural language from the rest
-        var lines = content.Split('\n');
-        if (lines.Length >= 2)
-        {
-            var firstLine = lines[0].Trim();
-            var remainingText = string.Join("\n", lines.Skip(1)).Trim();
-
-            // Check if first line is JSON with empty function_call
-            var jsonResult = TryParseJsonFunctionCallWithResponse(firstLine);
-            if (jsonResult != null && jsonResult.Value.FunctionCall == null)
-            {
-                // Empty function_call with natural language response
-                this._logger.LogInformation("Successfully parsed empty function call with natural language response");
-                return (null, remainingText);
-            }
-        }
-
-        // If not pure JSON, try to extract JSON from code blocks (```json ... ```)
-        var jsonContent = ExtractJsonFromCodeBlock(content);
-        if (!string.IsNullOrEmpty(jsonContent))
-        {
-            this._logger.LogInformation("Extracted JSON from code block: {JsonContent}", jsonContent);
-            var result = TryParseJsonFunctionCallWithResponse(jsonContent);
-            if (result != null)
-            {
-                this._logger.LogInformation("Successfully parsed function call from code block: {FunctionName}", result.Value.FunctionCall?.FunctionName);
-                return result;
-            }
-        }
-
-        // Fallback: try to parse without response format
-        var functionCallFromContent = TryParseJsonFunctionCall(content.Trim());
-        if (functionCallFromContent != null)
-        {
-            this._logger.LogInformation("Successfully parsed function call from pure JSON content (no response format): {FunctionName}", functionCallFromContent.FunctionName);
-            return (functionCallFromContent, null);
-        }
-
-        // If JSON parsing fails, try to extract function call using regex
-        var functionCallMatch = Regex.Match(content, @"(?:function_call|call|invoke)\s*:?\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\(([^)]*)\)",
-            RegexOptions.IgnoreCase);
-        if (functionCallMatch.Success)
-        {
-            var functionName = functionCallMatch.Groups[1].Value;
-            var argumentsString = functionCallMatch.Groups[2].Value;
-
-            this._logger.LogInformation("Successfully parsed function call using regex: {FunctionName}", functionName);
-            var functionCall = OnnxFunction.ParseFunctionCall(functionName, argumentsString);
-            return (functionCall, null);
-        }
-
-        this._logger.LogInformation("Failed to parse function call from content");
-        return null;
-    }
-
-    /// <summary>
-    /// Tries to parse a function call from the model's response (legacy method for backward compatibility).
-    /// </summary>
-    private FunctionCallContent? TryParseFunctionCall(string? content)
-    {
-        var result = TryParseFunctionCallWithResponse(content);
-        return result?.FunctionCall;
-    }
-
-    /// <summary>
-    /// Checks if the content contains a function call pattern.
-    /// </summary>
-    private static bool ContainsFunctionCall(string content)
-    {
-        if (string.IsNullOrEmpty(content))
-        {
-            return false;
-        }
-
-        // Check for JSON function call pattern
-        if (content.Contains("function_call") && content.Contains("{") && content.Contains("}"))
-        {
-            return true;
-        }
-
-        // Check for code block with function call
-        if (content.Contains("```") && content.Contains("function_call"))
-        {
-            return true;
-        }
-
-        return false;
-    }
-
-    /// <summary>
-    /// Extracts JSON content from markdown code blocks.
-    /// </summary>
-    private static string? ExtractJsonFromCodeBlock(string content)
-    {
-        // Match ```json ... ``` or ``` ... ``` patterns
-        var codeBlockMatch = Regex.Match(content, @"```(?:json)?\s*\n?(.*?)\n?```", RegexOptions.Singleline | RegexOptions.IgnoreCase);
-        if (codeBlockMatch.Success)
-        {
-            return codeBlockMatch.Groups[1].Value.Trim();
-        }
-
-        // Match `{...}` inline code blocks
-        var inlineCodeMatch = Regex.Match(content, @"`(\{.*?\})`", RegexOptions.Singleline);
-        if (inlineCodeMatch.Success)
-        {
-            return inlineCodeMatch.Groups[1].Value.Trim();
-        }
-
-        return null;
-    }
-
-    /// <summary>
-    /// Tries to parse a function call from JSON content.
-    /// </summary>
-    private static FunctionCallContent? TryParseJsonFunctionCall(string jsonContent)
-    {
-        try
-        {
-            var jsonDocument = JsonDocument.Parse(jsonContent);
-            if (jsonDocument.RootElement.TryGetProperty("function_call", out var functionCallElement))
-            {
-                if (functionCallElement.TryGetProperty("name", out var nameElement))
-                {
-                    var functionName = nameElement.GetString();
-
-                    if (!string.IsNullOrEmpty(functionName))
-                    {
-                        // Try to get arguments, use empty object if not present
-                        var argumentsJson = "{}";
-                        if (functionCallElement.TryGetProperty("arguments", out var argumentsElement))
-                        {
-                            argumentsJson = argumentsElement.GetRawText();
-                        }
-
-                        return OnnxFunction.ParseFunctionCall(functionName, argumentsJson);
-                    }
-                }
-            }
-        }
-        catch (JsonException)
-        {
-            // JSON parsing failed, return null to try other methods
-        }
-
-        return null;
-    }
-
-    /// <summary>
-    /// Tries to parse a function call with response format from JSON content.
-    /// </summary>
-    private static (FunctionCallContent? FunctionCall, string? ResponseFormat)? TryParseJsonFunctionCallWithResponse(string jsonContent)
-    {
-        try
-        {
-            var jsonDocument = JsonDocument.Parse(jsonContent);
-            if (jsonDocument.RootElement.TryGetProperty("function_call", out var functionCallElement))
-            {
-                // Check for response_format first
-                string? responseFormat = null;
-                if (jsonDocument.RootElement.TryGetProperty("response_format", out var responseFormatElement))
-                {
-                    responseFormat = responseFormatElement.GetString();
-                }
-
-                // Check if function_call is a string (direct function name)
-                if (functionCallElement.ValueKind == JsonValueKind.String)
-                {
-                    var functionName = functionCallElement.GetString();
-                    if (!string.IsNullOrEmpty(functionName))
-                    {
-                        var functionCall = OnnxFunction.ParseFunctionCall(functionName, "{}");
-                        return (functionCall, responseFormat);
-                    }
-                }
-
-                // Check if this is a natural language response (empty function_call)
-                if (functionCallElement.ValueKind == JsonValueKind.Object &&
-                    functionCallElement.EnumerateObject().Count() == 0)
-                {
-                    // Empty function_call means natural language response
-                    return (null, responseFormat);
-                }
-
-                // Check if this is an actual function call with name (arguments are optional)
-                if (functionCallElement.TryGetProperty("name", out var nameElement))
-                {
-                    var functionName = nameElement.GetString();
-
-                    if (!string.IsNullOrEmpty(functionName))
-                    {
-                        // Try to get arguments, use empty object if not present
-                        var argumentsJson = "{}";
-                        if (functionCallElement.TryGetProperty("arguments", out var argumentsElement))
-                        {
-                            argumentsJson = argumentsElement.GetRawText();
-                        }
-
-                        var functionCall = OnnxFunction.ParseFunctionCall(functionName, argumentsJson);
-                        return (functionCall, responseFormat);
-                    }
-                }
-            }
-        }
-        catch (JsonException)
-        {
-            // JSON parsing failed, return null to try other methods
-        }
-
-        return null;
+        this._functionInvoker ??= new OnnxFunctionInvoker(this.GetChatCompletionService(), this._logger);
+        return await this._functionInvoker.InvokeFunctionAsync(functionCall, responseFormat, toolCallingConfig, chatHistory, executionSettings, kernel, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -883,52 +452,5 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
         }
 
         return toolCallingConfig.Tools.Any(tool => tool.FunctionName == functionCallContent.FunctionName);
-    }
-
-    /// <summary>
-    /// Formats function result for better user experience.
-    /// </summary>
-    private static string FormatFunctionResult(string functionName, string functionResult)
-    {
-        // Handle null/empty results (typically from void functions)
-        if (string.IsNullOrEmpty(functionResult) || functionResult == "<null>")
-        {
-            return "Done.";
-        }
-
-        // Handle boolean results more naturally
-        if (bool.TryParse(functionResult, out bool boolResult))
-        {
-            return boolResult ? "Yes." : "No.";
-        }
-
-        // Return the result as-is for all other cases
-        return functionResult;
-    }
-
-    /// <summary>
-    /// Applies response format to the function result.
-    /// </summary>
-    private static string ApplyResponseFormat(string responseFormat, string functionResult)
-    {
-        try
-        {
-            // Replace {result} with the actual function result
-            var result = responseFormat.Replace("{result}", functionResult);
-
-            // If the response format doesn't contain {result}, it means the model provided a complete sentence
-            // Return it as-is (this is the versatile approach)
-            if (!responseFormat.Contains("{result}"))
-            {
-                return responseFormat;
-            }
-
-            return result;
-        }
-        catch (Exception)
-        {
-            // If any error occurs during formatting, return the original function result
-            return functionResult;
-        }
     }
 }

--- a/dotnet/src/Connectors/Connectors.Onnx/OnnxRuntimeGenAIFunctionCallingChatCompletionService.cs
+++ b/dotnet/src/Connectors/Connectors.Onnx/OnnxRuntimeGenAIFunctionCallingChatCompletionService.cs
@@ -23,7 +23,8 @@ namespace Microsoft.SemanticKernel.Connectors.Onnx;
 /// </summary>
 public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChatCompletionService, IDisposable
 {
-    private readonly string _modelPath;
+    private readonly Config _config;
+    private readonly Model _model;
     private readonly ILogger _logger;
     private readonly FunctionCallsProcessor _functionCallsProcessor;
     private OnnxRuntimeGenAIChatClient? _chatClient;
@@ -40,26 +41,40 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
     /// <param name="modelPath">The generative AI ONNX model path for the chat completion service.</param>
     /// <param name="loggerFactory">Optional logger factory to be used for logging.</param>
     /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for various aspects of serialization and deserialization required by the service.</param>
+    /// <param name="providers">The providers to use for the chat completion service.</param>
     public OnnxRuntimeGenAIFunctionCallingChatCompletionService(
         string modelId,
         string modelPath,
         ILoggerFactory? loggerFactory = null,
-        JsonSerializerOptions? jsonSerializerOptions = null)
+        JsonSerializerOptions? jsonSerializerOptions = null,
+        List<string>? providers = null)
     {
         Verify.NotNullOrWhiteSpace(modelId);
         Verify.NotNullOrWhiteSpace(modelPath);
 
         this._attributesInternal.Add(AIServiceExtensions.ModelIdKey, modelId);
-        this._modelPath = modelPath;
-        this._logger = loggerFactory?.CreateLogger<OnnxRuntimeGenAIFunctionCallingChatCompletionService>() ?? NullLogger<OnnxRuntimeGenAIFunctionCallingChatCompletionService>.Instance;
+        this._config = new Config(modelPath);
+        if (providers != null)
+        {
+            this._config.ClearProviders();
+            foreach (string provider in providers)
+            {
+                this._config.AppendProvider(provider);
+            }
+        }
+        this._model = new Model(this._config);
+
+        this._logger = loggerFactory?.CreateLogger<OnnxRuntimeGenAIFunctionCallingChatCompletionService>() ??
+                       NullLogger<OnnxRuntimeGenAIFunctionCallingChatCompletionService>.Instance;
         this._functionCallsProcessor = new FunctionCallsProcessor(this._logger);
-        
-        this._logger.LogInformation("OnnxRuntimeGenAIFunctionCallingChatCompletionService initialized with model: {ModelId} at path: {ModelPath}", modelId, modelPath);
+
+        this._logger.LogInformation("OnnxRuntimeGenAIFunctionCallingChatCompletionService initialized with model: {ModelId} at path: {ModelPath}",
+            modelId, modelPath);
     }
 
     private IChatCompletionService GetChatCompletionService()
     {
-        this._chatClient ??= new OnnxRuntimeGenAIChatClient(this._modelPath, new OnnxRuntimeGenAIChatClientOptions()
+        this._chatClient ??= new OnnxRuntimeGenAIChatClient(this._model, true, new OnnxRuntimeGenAIChatClientOptions
         {
             PromptFormatter = (messages, options) =>
             {
@@ -115,7 +130,12 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
     }
 
     /// <inheritdoc/>
-    public void Dispose() => this._chatClient?.Dispose();
+    public void Dispose()
+    {
+        this._chatClient?.Dispose();
+        this._model.Dispose();
+        this._config.Dispose();
+    }
 
     /// <inheritdoc/>
     public async Task<IReadOnlyList<ChatMessageContent>> GetChatMessageContentsAsync(
@@ -125,21 +145,23 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
         CancellationToken cancellationToken = default)
     {
         this._logger.LogInformation("GetChatMessageContentsAsync called");
-        
+
         var onnxExecutionSettings = GetOnnxExecutionSettings(executionSettings);
         var toolCallingConfig = GetToolCallingConfig(onnxExecutionSettings, kernel, chatHistory, 0);
 
         this._logger.LogInformation("Tool calling config: {Config}", toolCallingConfig != null ? "configured" : "null");
         if (toolCallingConfig != null)
         {
-            this._logger.LogInformation("Tools count: {Count}, AutoInvoke: {AutoInvoke}", toolCallingConfig.Tools?.Count ?? 0, toolCallingConfig.AutoInvoke);
+            this._logger.LogInformation("Tools count: {Count}, AutoInvoke: {AutoInvoke}", toolCallingConfig.Tools?.Count ?? 0,
+                toolCallingConfig.AutoInvoke);
         }
 
         // If no function calling is configured, use the base service
         if (toolCallingConfig is null || toolCallingConfig.Tools is null || toolCallingConfig.Tools.Count == 0)
         {
             this._logger.LogInformation("No function calling configured, using base service");
-            return await this.GetChatCompletionService().GetChatMessageContentsAsync(chatHistory, executionSettings, kernel, cancellationToken).ConfigureAwait(false);
+            return await this.GetChatCompletionService().GetChatMessageContentsAsync(chatHistory, executionSettings, kernel, cancellationToken)
+                .ConfigureAwait(false);
         }
 
         this._logger.LogInformation("Function calling is configured, processing with function calling");
@@ -148,7 +170,8 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
         var modifiedChatHistory = await this.CreateModifiedChatHistoryAsync(chatHistory, toolCallingConfig, cancellationToken).ConfigureAwait(false);
 
         // Get the response from the underlying service
-        var results = await this.GetChatCompletionService().GetChatMessageContentsAsync(modifiedChatHistory, executionSettings, kernel, cancellationToken).ConfigureAwait(false);
+        var results = await this.GetChatCompletionService()
+            .GetChatMessageContentsAsync(modifiedChatHistory, executionSettings, kernel, cancellationToken).ConfigureAwait(false);
 
         this._logger.LogInformation("Got {Count} results from base service", results.Count);
         foreach (var result in results)
@@ -157,8 +180,10 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
         }
 
         // Process the results for function calls
-        var processedResults = await this.ProcessChatMessageContentsAsync(results, toolCallingConfig, chatHistory, 0, executionSettings, kernel, cancellationToken).ConfigureAwait(false);
-        
+        var processedResults = await this
+            .ProcessChatMessageContentsAsync(results, toolCallingConfig, chatHistory, 0, executionSettings, kernel, cancellationToken)
+            .ConfigureAwait(false);
+
         this._logger.LogInformation("Processed {Count} results", processedResults.Count);
         foreach (var result in processedResults)
         {
@@ -182,7 +207,8 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
         // If no function calling is configured, use the base service
         if (toolCallingConfig is null || toolCallingConfig.Tools is null || toolCallingConfig.Tools.Count == 0)
         {
-            await foreach (var content in this.GetChatCompletionService().GetStreamingChatMessageContentsAsync(chatHistory, executionSettings, kernel, cancellationToken).ConfigureAwait(false))
+            await foreach (var content in this.GetChatCompletionService()
+                               .GetStreamingChatMessageContentsAsync(chatHistory, executionSettings, kernel, cancellationToken).ConfigureAwait(false))
             {
                 yield return content;
             }
@@ -198,11 +224,13 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
         var hasFunctionCall = false;
         var functionCallContent = new List<StreamingChatMessageContent>();
 
-        await foreach (var content in this.GetChatCompletionService().GetStreamingChatMessageContentsAsync(modifiedChatHistory, executionSettings, kernel, cancellationToken).ConfigureAwait(false))
+        await foreach (var content in this.GetChatCompletionService()
+                           .GetStreamingChatMessageContentsAsync(modifiedChatHistory, executionSettings, kernel, cancellationToken)
+                           .ConfigureAwait(false))
         {
             responseBuilder.Append(content.Content);
             functionCallContent.Add(content);
-            
+
             // Check if we have a complete function call
             var currentResponse = responseBuilder.ToString();
             if (!hasFunctionCall && ContainsFunctionCall(currentResponse))
@@ -210,7 +238,7 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
                 hasFunctionCall = true;
                 this._logger.LogInformation("Detected function call in streaming response");
             }
-            
+
             // If we have a function call, don't yield the content yet
             if (!hasFunctionCall)
             {
@@ -222,8 +250,10 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
         if (hasFunctionCall)
         {
             var completeResponse = new ChatMessageContent(AuthorRole.Assistant, responseBuilder.ToString());
-            var processedResponse = await this.ProcessSingleChatMessageForFunctionCallsAsync(completeResponse, toolCallingConfig, chatHistory, 0, executionSettings, kernel, cancellationToken).ConfigureAwait(false);
-            
+            var processedResponse = await this
+                .ProcessSingleChatMessageForFunctionCallsAsync(completeResponse, toolCallingConfig, chatHistory, 0, executionSettings, kernel,
+                    cancellationToken).ConfigureAwait(false);
+
             // Yield the processed response instead of the original JSON
             if (processedResponse.Content != completeResponse.Content)
             {
@@ -290,7 +320,7 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
         if (toolCallingConfig.Tools is not null && toolCallingConfig.Tools.Count > 0)
         {
             var functionsJson = CreateFunctionsJson(toolCallingConfig.Tools);
-            var systemMessage = $"You are a helpful assistant with access to the following functions. Use them when appropriate:\n\n{functionsJson}\n\nWhen you want to call a function, respond with JSON in the format: {{\"function_call\": {{\"name\": \"function_name\", \"arguments\": {{\"param1\": \"value1\"}}}}}}\n\nDo not include any other text when making a function call.";
+            var systemMessage = $"You are a helpful assistant with access to the following functions:\n\n{functionsJson}\n\nIMPORTANT: When the user asks for information that requires a function, respond with ONLY JSON: {{\"function_call\": {{\"name\": \"function_name\", \"arguments\": {{}}}}}}\n\nWhen the user asks for natural language responses or general questions, respond with ONLY JSON: {{\"function_call\": {{}}, \"response_format\": \"your natural language response here\"}}\n\nYou can use {{result}} in response_format to include function results, or provide a complete sentence without placeholders.\n\nNEVER include explanatory text or code blocks. Respond with ONLY the JSON format.";
 
             modifiedChatHistory.AddSystemMessage(systemMessage);
         }
@@ -332,13 +362,15 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
         CancellationToken cancellationToken)
     {
         this._logger.LogInformation("ProcessChatMessageContentsAsync called with {Count} results", results.Count);
-        
+
         var processedResults = new List<ChatMessageContent>();
 
         foreach (var result in results)
         {
             this._logger.LogInformation("Processing result: {Content}", result.Content);
-            var processedResult = await this.ProcessSingleChatMessageForFunctionCallsAsync(result, toolCallingConfig, chatHistory, requestIndex, executionSettings, kernel, cancellationToken).ConfigureAwait(false);
+            var processedResult = await this
+                .ProcessSingleChatMessageForFunctionCallsAsync(result, toolCallingConfig, chatHistory, requestIndex, executionSettings, kernel,
+                    cancellationToken).ConfigureAwait(false);
             this._logger.LogInformation("Processed result: {Content}", processedResult.Content);
             processedResults.Add(processedResult);
         }
@@ -363,11 +395,31 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
             return result;
         }
 
+        // Quick pre-check: if content doesn't contain function call patterns, skip parsing
+        if (!ContainsFunctionCall(result.Content))
+        {
+            this._logger.LogDebug("Content does not contain function call patterns, skipping parsing");
+            return result;
+        }
+
         // Try to parse function call from the response
-        var functionCall = TryParseFunctionCall(result.Content);
-        if (functionCall is null)
+        var parseResult = TryParseFunctionCallWithResponse(result.Content);
+        if (parseResult is null)
         {
             return result;
+        }
+
+        var functionCall = parseResult.Value.FunctionCall;
+        var responseFormat = parseResult.Value.ResponseFormat;
+
+        // If functionCall is null, this is a natural language response
+        if (functionCall == null)
+        {
+            this._logger.LogInformation("Detected natural language response with response_format: {ResponseFormat}", responseFormat);
+            
+            // Create a new message with the response format content
+            var newContent = !string.IsNullOrEmpty(responseFormat) ? responseFormat : result.Content;
+            return new ChatMessageContent(AuthorRole.Assistant, newContent);
         }
 
         // Add function call to the result
@@ -408,7 +460,7 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
 
         // Fallback: Manual function invocation if standard processing fails or returns JSON
         this._logger.LogInformation("Using manual fallback for function call");
-        return await TryManualFunctionInvocationAsync(result, functionCall, toolCallingConfig, kernel, cancellationToken).ConfigureAwait(false);
+        return await TryManualFunctionInvocationAsync(result, functionCall, responseFormat, toolCallingConfig, kernel, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -421,8 +473,22 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
         Kernel kernel,
         CancellationToken cancellationToken)
     {
+        return await TryManualFunctionInvocationAsync(result, functionCall, null, toolCallingConfig, kernel, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Manual fallback for function invocation when standard processing fails.
+    /// </summary>
+    private async Task<ChatMessageContent> TryManualFunctionInvocationAsync(
+        ChatMessageContent result,
+        FunctionCallContent functionCall,
+        string? responseFormat,
+        OnnxToolCallingConfig toolCallingConfig,
+        Kernel kernel,
+        CancellationToken cancellationToken)
+    {
         this._logger.LogInformation("Manual fallback invoked for function: {FunctionName}", functionCall.FunctionName);
-        
+
         try
         {
             // Check if the function call is valid
@@ -442,17 +508,30 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
 
             // Invoke the function
             this._logger.LogInformation("Manually invoking function {PluginName}.{FunctionName}", function.PluginName, function.Name);
-            
+
             var functionResult = await kernel.InvokeAsync(function, arguments: null, cancellationToken).ConfigureAwait(false);
             var value = functionResult.GetValue<object>();
             string resultValue = value?.ToString() ?? "<null>";
 
+            // Apply post-processing if response format is specified
+            string finalResult;
+            if (!string.IsNullOrEmpty(responseFormat))
+            {
+                this._logger.LogInformation("Applying response format: {ResponseFormat}", responseFormat);
+                finalResult = ApplyResponseFormat(responseFormat, resultValue);
+                this._logger.LogInformation("Applied response format. Original: {Original}, Final: {Final}", resultValue, finalResult);
+            }
+            else
+            {
+                finalResult = resultValue;
+            }
+
             // Create a new message with the function result
-            var functionResultMessage = new ChatMessageContent(AuthorRole.Assistant, resultValue ?? string.Empty);
-            
+            var functionResultMessage = new ChatMessageContent(AuthorRole.Assistant, finalResult ?? string.Empty);
+
             this._logger.LogInformation("Function {PluginName}.{FunctionName} returned: {Result}", function.PluginName, function.Name, resultValue);
             this._logger.LogInformation("Manual fallback returning message: {Message}", functionResultMessage.Content);
-            
+
             return functionResultMessage;
         }
         catch (Exception ex)
@@ -465,7 +544,7 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
     /// <summary>
     /// Tries to parse a function call from the model's response.
     /// </summary>
-    private FunctionCallContent? TryParseFunctionCall(string? content)
+    private (FunctionCallContent? FunctionCall, string? ResponseFormat)? TryParseFunctionCallWithResponse(string? content)
     {
         if (string.IsNullOrEmpty(content))
         {
@@ -474,40 +553,115 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
 
         this._logger.LogInformation("Attempting to parse function call from content: {Content}", content);
 
-        // First, try to extract JSON from code blocks (```json ... ```)
+        // First, try to parse the entire content as pure JSON with response format
+        var resultFromContent = TryParseJsonFunctionCallWithResponse(content.Trim());
+        if (resultFromContent != null)
+        {
+            this._logger.LogInformation("Successfully parsed function call from pure JSON content: {FunctionName}", resultFromContent.Value.FunctionCall?.FunctionName);
+            return resultFromContent;
+        }
+
+        // --- Robustness: Try to fix missing closing brace ---
+        var trimmed = content.Trim();
+        if (trimmed.StartsWith("{") && trimmed.Contains("function_call") && !trimmed.EndsWith("}"))
+        {
+            var fixedJson = trimmed + "}";
+            var fixedResult = TryParseJsonFunctionCallWithResponse(fixedJson);
+            if (fixedResult != null)
+            {
+                this._logger.LogInformation("Successfully parsed function call from auto-corrected JSON (added closing brace)");
+                return fixedResult;
+            }
+        }
+        // -----------------------------------------------------
+
+        // Try to extract JSON from the first line and natural language from the rest
+        var lines = content.Split('\n');
+        if (lines.Length >= 2)
+        {
+            var firstLine = lines[0].Trim();
+            var remainingText = string.Join("\n", lines.Skip(1)).Trim();
+            
+            // Check if first line is JSON with empty function_call
+            var jsonResult = TryParseJsonFunctionCallWithResponse(firstLine);
+            if (jsonResult != null && jsonResult.Value.FunctionCall == null)
+            {
+                // Empty function_call with natural language response
+                this._logger.LogInformation("Successfully parsed empty function call with natural language response");
+                return (null, remainingText);
+            }
+        }
+
+        // If not pure JSON, try to extract JSON from code blocks (```json ... ```)
         var jsonContent = ExtractJsonFromCodeBlock(content);
         if (!string.IsNullOrEmpty(jsonContent))
         {
             this._logger.LogInformation("Extracted JSON from code block: {JsonContent}", jsonContent);
-            var functionCall = TryParseJsonFunctionCall(jsonContent);
-            if (functionCall != null)
+            var result = TryParseJsonFunctionCallWithResponse(jsonContent);
+            if (result != null)
             {
-                this._logger.LogInformation("Successfully parsed function call from code block: {FunctionName}", functionCall.FunctionName);
-                return functionCall;
+                this._logger.LogInformation("Successfully parsed function call from code block: {FunctionName}", result.Value.FunctionCall?.FunctionName);
+                return result;
             }
         }
 
-        // Try to parse the entire content as JSON
-        var functionCallFromContent = TryParseJsonFunctionCall(content);
+        // Fallback: try to parse without response format
+        var functionCallFromContent = TryParseJsonFunctionCall(content.Trim());
         if (functionCallFromContent != null)
         {
-            this._logger.LogInformation("Successfully parsed function call from content: {FunctionName}", functionCallFromContent.FunctionName);
-            return functionCallFromContent;
+            this._logger.LogInformation("Successfully parsed function call from pure JSON content (no response format): {FunctionName}", functionCallFromContent.FunctionName);
+            return (functionCallFromContent, null);
         }
 
         // If JSON parsing fails, try to extract function call using regex
-        var functionCallMatch = Regex.Match(content, @"(?:function_call|call|invoke)\s*:?\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\(([^)]*)\)", RegexOptions.IgnoreCase);
+        var functionCallMatch = Regex.Match(content, @"(?:function_call|call|invoke)\s*:?\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\(([^)]*)\)",
+            RegexOptions.IgnoreCase);
         if (functionCallMatch.Success)
         {
             var functionName = functionCallMatch.Groups[1].Value;
             var argumentsString = functionCallMatch.Groups[2].Value;
 
             this._logger.LogInformation("Successfully parsed function call using regex: {FunctionName}", functionName);
-            return OnnxFunction.ParseFunctionCall(functionName, argumentsString);
+            var functionCall = OnnxFunction.ParseFunctionCall(functionName, argumentsString);
+            return (functionCall, null);
         }
 
         this._logger.LogInformation("Failed to parse function call from content");
         return null;
+    }
+
+    /// <summary>
+    /// Tries to parse a function call from the model's response (legacy method for backward compatibility).
+    /// </summary>
+    private FunctionCallContent? TryParseFunctionCall(string? content)
+    {
+        var result = TryParseFunctionCallWithResponse(content);
+        return result?.FunctionCall;
+    }
+
+    /// <summary>
+    /// Checks if the content contains a function call pattern.
+    /// </summary>
+    private static bool ContainsFunctionCall(string content)
+    {
+        if (string.IsNullOrEmpty(content))
+        {
+            return false;
+        }
+
+        // Check for JSON function call pattern
+        if (content.Contains("function_call") && content.Contains("{") && content.Contains("}"))
+        {
+            return true;
+        }
+
+        // Check for code block with function call
+        if (content.Contains("```") && content.Contains("function_call"))
+        {
+            return true;
+        }
+
+        return false;
     }
 
     /// <summary>
@@ -564,6 +718,54 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
     }
 
     /// <summary>
+    /// Tries to parse a function call with response format from JSON content.
+    /// </summary>
+    private static (FunctionCallContent? FunctionCall, string? ResponseFormat)? TryParseJsonFunctionCallWithResponse(string jsonContent)
+    {
+        try
+        {
+            var jsonDocument = JsonDocument.Parse(jsonContent);
+            if (jsonDocument.RootElement.TryGetProperty("function_call", out var functionCallElement))
+            {
+                // Check for response_format first
+                string? responseFormat = null;
+                if (jsonDocument.RootElement.TryGetProperty("response_format", out var responseFormatElement))
+                {
+                    responseFormat = responseFormatElement.GetString();
+                }
+
+                // Check if this is a natural language response (empty function_call)
+                if (functionCallElement.ValueKind == JsonValueKind.Object && 
+                    functionCallElement.EnumerateObject().Count() == 0)
+                {
+                    // Empty function_call means natural language response
+                    return (null, responseFormat);
+                }
+
+                // Check if this is an actual function call
+                if (functionCallElement.TryGetProperty("name", out var nameElement) &&
+                    functionCallElement.TryGetProperty("arguments", out var argumentsElement))
+                {
+                    var functionName = nameElement.GetString();
+                    var argumentsJson = argumentsElement.GetRawText();
+
+                    if (!string.IsNullOrEmpty(functionName))
+                    {
+                        var functionCall = OnnxFunction.ParseFunctionCall(functionName, argumentsJson);
+                        return (functionCall, responseFormat);
+                    }
+                }
+            }
+        }
+        catch (JsonException)
+        {
+            // JSON parsing failed, return null to try other methods
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// Checks if a function call is valid (i.e., the function was advertised to the model).
     /// </summary>
     private static bool IsValidFunctionCall(FunctionCallContent functionCallContent, OnnxToolCallingConfig toolCallingConfig)
@@ -582,27 +784,28 @@ public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChat
     }
 
     /// <summary>
-    /// Checks if the content contains a function call pattern.
+    /// Applies response format to the function result.
     /// </summary>
-    private static bool ContainsFunctionCall(string content)
+    private static string ApplyResponseFormat(string responseFormat, string functionResult)
     {
-        if (string.IsNullOrEmpty(content))
+        try
         {
-            return false;
-        }
+            // Replace {result} with the actual function result
+            var result = responseFormat.Replace("{result}", functionResult);
 
-        // Check for JSON function call pattern
-        if (content.Contains("function_call") && content.Contains("{") && content.Contains("}"))
+            // If the response format doesn't contain {result}, it means the model provided a complete sentence
+            // Return it as-is (this is the versatile approach)
+            if (!responseFormat.Contains("{result}"))
+            {
+                return responseFormat;
+            }
+
+            return result;
+        }
+        catch (Exception)
         {
-            return true;
+            // If any error occurs during formatting, return the original function result
+            return functionResult;
         }
-
-        // Check for code block with function call
-        if (content.Contains("```") && content.Contains("function_call"))
-        {
-            return true;
-        }
-
-        return false;
     }
 }

--- a/dotnet/src/Connectors/Connectors.Onnx/OnnxRuntimeGenAIFunctionCallingChatCompletionService.cs
+++ b/dotnet/src/Connectors/Connectors.Onnx/OnnxRuntimeGenAIFunctionCallingChatCompletionService.cs
@@ -1,0 +1,347 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.ML.OnnxRuntimeGenAI;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.Connectors.FunctionCalling;
+using Microsoft.SemanticKernel.Services;
+
+namespace Microsoft.SemanticKernel.Connectors.Onnx;
+
+/// <summary>
+/// Represents a chat completion service using OnnxRuntimeGenAI with function calling support.
+/// </summary>
+public sealed class OnnxRuntimeGenAIFunctionCallingChatCompletionService : IChatCompletionService, IDisposable
+{
+    private readonly string _modelPath;
+    private readonly ILogger _logger;
+    private readonly FunctionCallsProcessor _functionCallsProcessor;
+    private OnnxRuntimeGenAIChatClient? _chatClient;
+    private IChatCompletionService? _chatClientWrapper;
+    private readonly Dictionary<string, object?> _attributesInternal = [];
+
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<string, object?> Attributes => this._attributesInternal;
+
+    /// <summary>
+    /// Initializes a new instance of the OnnxRuntimeGenAIFunctionCallingChatCompletionService class.
+    /// </summary>
+    /// <param name="modelId">The name of the model.</param>
+    /// <param name="modelPath">The generative AI ONNX model path for the chat completion service.</param>
+    /// <param name="loggerFactory">Optional logger factory to be used for logging.</param>
+    /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for various aspects of serialization and deserialization required by the service.</param>
+    public OnnxRuntimeGenAIFunctionCallingChatCompletionService(
+        string modelId,
+        string modelPath,
+        ILoggerFactory? loggerFactory = null,
+        JsonSerializerOptions? jsonSerializerOptions = null)
+    {
+        Verify.NotNullOrWhiteSpace(modelId);
+        Verify.NotNullOrWhiteSpace(modelPath);
+
+        this._attributesInternal.Add(AIServiceExtensions.ModelIdKey, modelId);
+        this._modelPath = modelPath;
+        this._logger = loggerFactory?.CreateLogger<OnnxRuntimeGenAIFunctionCallingChatCompletionService>() ?? NullLogger<OnnxRuntimeGenAIFunctionCallingChatCompletionService>.Instance;
+        this._functionCallsProcessor = new FunctionCallsProcessor(this._logger);
+    }
+
+    private IChatCompletionService GetChatCompletionService()
+    {
+        this._chatClient ??= new OnnxRuntimeGenAIChatClient(this._modelPath, new OnnxRuntimeGenAIChatClientOptions()
+        {
+            PromptFormatter = (messages, options) =>
+            {
+                StringBuilder promptBuilder = new();
+                foreach (var message in messages)
+                {
+                    promptBuilder.Append($"<|{message.Role}|>\n{message.Text}");
+                }
+                promptBuilder.Append("<|end|>\n<|assistant|>");
+
+                return promptBuilder.ToString();
+            }
+        });
+
+        return this._chatClientWrapper ??= this._chatClient.AsChatCompletionService();
+    }
+
+    /// <inheritdoc/>
+    public void Dispose() => this._chatClient?.Dispose();
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<ChatMessageContent>> GetChatMessageContentsAsync(
+        ChatHistory chatHistory,
+        PromptExecutionSettings? executionSettings = null,
+        Kernel? kernel = null,
+        CancellationToken cancellationToken = default)
+    {
+        var onnxExecutionSettings = GetOnnxExecutionSettings(executionSettings);
+        var toolCallingConfig = GetToolCallingConfig(onnxExecutionSettings, kernel, chatHistory, 0);
+
+        // If no function calling is configured, use the base service
+        if (toolCallingConfig is null || toolCallingConfig.Tools is null || toolCallingConfig.Tools.Count == 0)
+        {
+            return await this.GetChatCompletionService().GetChatMessageContentsAsync(chatHistory, executionSettings, kernel, cancellationToken);
+        }
+
+        // Create a modified chat history with function definitions
+        var modifiedChatHistory = await this.CreateModifiedChatHistoryAsync(chatHistory, toolCallingConfig, cancellationToken);
+
+        // Get the response from the underlying service
+        var results = await this.GetChatCompletionService().GetChatMessageContentsAsync(modifiedChatHistory, executionSettings, kernel, cancellationToken);
+
+        // Process the results for function calls
+        return await this.ProcessChatMessageContentsAsync(results, toolCallingConfig, chatHistory, 0, executionSettings, kernel, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async IAsyncEnumerable<StreamingChatMessageContent> GetStreamingChatMessageContentsAsync(
+        ChatHistory chatHistory,
+        PromptExecutionSettings? executionSettings = null,
+        Kernel? kernel = null,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var onnxExecutionSettings = GetOnnxExecutionSettings(executionSettings);
+        var toolCallingConfig = GetToolCallingConfig(onnxExecutionSettings, kernel, chatHistory, 0);
+
+        // If no function calling is configured, use the base service
+        if (toolCallingConfig is null || toolCallingConfig.Tools is null || toolCallingConfig.Tools.Count == 0)
+        {
+            await foreach (var content in this.GetChatCompletionService().GetStreamingChatMessageContentsAsync(chatHistory, executionSettings, kernel, cancellationToken))
+            {
+                yield return content;
+            }
+            yield break;
+        }
+
+        // Create a modified chat history with function definitions
+        var modifiedChatHistory = await this.CreateModifiedChatHistoryAsync(chatHistory, toolCallingConfig, cancellationToken);
+
+        // Get the streaming response from the underlying service
+        var responseBuilder = new StringBuilder();
+        var streamingResults = new List<StreamingChatMessageContent>();
+
+        await foreach (var content in this.GetChatCompletionService().GetStreamingChatMessageContentsAsync(modifiedChatHistory, executionSettings, kernel, cancellationToken))
+        {
+            streamingResults.Add(content);
+            responseBuilder.Append(content.Content);
+            yield return content;
+        }
+
+        // Process the complete response for function calls
+        var completeResponse = new ChatMessageContent(AuthorRole.Assistant, responseBuilder.ToString());
+        await this.ProcessSingleChatMessageForFunctionCallsAsync(completeResponse, toolCallingConfig, chatHistory, 0, executionSettings, kernel, cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets the ONNX execution settings from the provided execution settings.
+    /// </summary>
+    private static OnnxRuntimeGenAIPromptExecutionSettings GetOnnxExecutionSettings(PromptExecutionSettings? executionSettings)
+    {
+        return executionSettings switch
+        {
+            null => new OnnxRuntimeGenAIPromptExecutionSettings(),
+            OnnxRuntimeGenAIPromptExecutionSettings onnxSettings => onnxSettings,
+            _ => OnnxRuntimeGenAIPromptExecutionSettings.FromExecutionSettings(executionSettings)
+        };
+    }
+
+    /// <summary>
+    /// Gets the tool calling configuration from the execution settings.
+    /// </summary>
+    private OnnxToolCallingConfig? GetToolCallingConfig(
+        OnnxRuntimeGenAIPromptExecutionSettings executionSettings,
+        Kernel? kernel,
+        ChatHistory chatHistory,
+        int requestIndex)
+    {
+        if (executionSettings.ToolCallBehavior is null)
+        {
+            return null;
+        }
+
+        return executionSettings.ToolCallBehavior.ConfigureRequest(kernel, chatHistory, requestIndex);
+    }
+
+    /// <summary>
+    /// Creates a modified chat history with function definitions included.
+    /// </summary>
+    private async Task<ChatHistory> CreateModifiedChatHistoryAsync(
+        ChatHistory originalChatHistory,
+        OnnxToolCallingConfig toolCallingConfig,
+        CancellationToken cancellationToken)
+    {
+        var modifiedChatHistory = new ChatHistory();
+
+        // Add function definitions as a system message
+        if (toolCallingConfig.Tools is not null && toolCallingConfig.Tools.Count > 0)
+        {
+            var functionsJson = CreateFunctionsJson(toolCallingConfig.Tools);
+            var systemMessage = $"You are a helpful assistant with access to the following functions. Use them when appropriate:\n\n{functionsJson}\n\nWhen you want to call a function, respond with JSON in the format: {{\"function_call\": {{\"name\": \"function_name\", \"arguments\": {{\"param1\": \"value1\"}}}}}}\n\nDo not include any other text when making a function call.";
+            
+            modifiedChatHistory.AddSystemMessage(systemMessage);
+        }
+
+        // Add original chat history
+        foreach (var message in originalChatHistory)
+        {
+            modifiedChatHistory.Add(message);
+        }
+
+        return modifiedChatHistory;
+    }
+
+    /// <summary>
+    /// Creates a JSON representation of the available functions.
+    /// </summary>
+    private static string CreateFunctionsJson(IList<OnnxFunction> functions)
+    {
+        var functionsArray = new JsonArray();
+        
+        foreach (var function in functions)
+        {
+            functionsArray.Add(function.ToFunctionDefinition());
+        }
+
+        return functionsArray.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    /// <summary>
+    /// Processes chat message contents for function calls.
+    /// </summary>
+    private async Task<IReadOnlyList<ChatMessageContent>> ProcessChatMessageContentsAsync(
+        IReadOnlyList<ChatMessageContent> results,
+        OnnxToolCallingConfig toolCallingConfig,
+        ChatHistory chatHistory,
+        int requestIndex,
+        PromptExecutionSettings? executionSettings,
+        Kernel? kernel,
+        CancellationToken cancellationToken)
+    {
+        var processedResults = new List<ChatMessageContent>();
+
+        foreach (var result in results)
+        {
+            var processedResult = await this.ProcessSingleChatMessageForFunctionCallsAsync(
+                result, toolCallingConfig, chatHistory, requestIndex, executionSettings, kernel, cancellationToken);
+            processedResults.Add(processedResult);
+        }
+
+        return processedResults;
+    }
+
+    /// <summary>
+    /// Processes a single chat message for function calls.
+    /// </summary>
+    private async Task<ChatMessageContent> ProcessSingleChatMessageForFunctionCallsAsync(
+        ChatMessageContent result,
+        OnnxToolCallingConfig toolCallingConfig,
+        ChatHistory chatHistory,
+        int requestIndex,
+        PromptExecutionSettings? executionSettings,
+        Kernel? kernel,
+        CancellationToken cancellationToken)
+    {
+        if (!toolCallingConfig.AutoInvoke || kernel is null)
+        {
+            return result;
+        }
+
+        // Try to parse function call from the response
+        var functionCall = TryParseFunctionCall(result.Content);
+        if (functionCall is null)
+        {
+            return result;
+        }
+
+        // Add function call to the result
+        result.Items.Add(functionCall);
+
+        // Process function calls if auto-invoke is enabled
+        var lastMessage = await this._functionCallsProcessor.ProcessFunctionCallsAsync(
+            result,
+            executionSettings,
+            chatHistory,
+            requestIndex,
+            (functionCallContent) => IsValidFunctionCall(functionCallContent, toolCallingConfig),
+            toolCallingConfig.Options ?? new FunctionChoiceBehaviorOptions(),
+            kernel,
+            isStreaming: false,
+            cancellationToken);
+
+        return lastMessage ?? result;
+    }
+
+    /// <summary>
+    /// Tries to parse a function call from the model's response.
+    /// </summary>
+    private static FunctionCallContent? TryParseFunctionCall(string? content)
+    {
+        if (string.IsNullOrEmpty(content))
+        {
+            return null;
+        }
+
+        try
+        {
+            // Try to parse as JSON
+            var jsonDocument = JsonDocument.Parse(content);
+            if (jsonDocument.RootElement.TryGetProperty("function_call", out var functionCallElement))
+            {
+                if (functionCallElement.TryGetProperty("name", out var nameElement) &&
+                    functionCallElement.TryGetProperty("arguments", out var argumentsElement))
+                {
+                    var functionName = nameElement.GetString();
+                    var argumentsJson = argumentsElement.GetRawText();
+
+                    if (!string.IsNullOrEmpty(functionName))
+                    {
+                        return OnnxFunction.ParseFunctionCall(functionName, argumentsJson);
+                    }
+                }
+            }
+        }
+        catch (JsonException)
+        {
+            // If JSON parsing fails, try to extract function call using regex
+            var functionCallMatch = Regex.Match(content, @"(?:function_call|call|invoke)\s*:?\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\(([^)]*)\)", RegexOptions.IgnoreCase);
+            if (functionCallMatch.Success)
+            {
+                var functionName = functionCallMatch.Groups[1].Value;
+                var argumentsString = functionCallMatch.Groups[2].Value;
+
+                return OnnxFunction.ParseFunctionCall(functionName, argumentsString);
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Checks if a function call is valid (i.e., the function was advertised to the model).
+    /// </summary>
+    private static bool IsValidFunctionCall(FunctionCallContent functionCallContent, OnnxToolCallingConfig toolCallingConfig)
+    {
+        if (toolCallingConfig.AllowAnyRequestedKernelFunction)
+        {
+            return true;
+        }
+
+        if (toolCallingConfig.Tools is null)
+        {
+            return false;
+        }
+
+        return toolCallingConfig.Tools.Any(tool => tool.FunctionName == functionCallContent.FunctionName);
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Onnx/OnnxRuntimeGenAIPromptExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.Onnx/OnnxRuntimeGenAIPromptExecutionSettings.cs
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
+using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Text;
 
 namespace Microsoft.SemanticKernel.Connectors.Onnx;
@@ -180,5 +182,36 @@ public sealed class OnnxRuntimeGenAIPromptExecutionSettings : PromptExecutionSet
     /// <see cref="ChatHistory"/> if an instance was provided.
     /// </remarks>
     [JsonIgnore]
-    public OnnxToolCallBehavior? ToolCallBehavior { get; set; }
+    public OnnxToolCallBehavior? ToolCallBehavior
+    {
+        get => _toolCallBehavior;
+        set
+        {
+            if (value is not null && this.FunctionChoiceBehavior is not null)
+            {
+                throw new InvalidOperationException("ToolCallBehavior and FunctionChoiceBehavior cannot be used together. Please use only one of them.");
+            }
+            _toolCallBehavior = value;
+        }
+    }
+
+    private OnnxToolCallBehavior? _toolCallBehavior;
+
+    /// <summary>
+    /// Gets or sets the function choice behavior for the ONNX model.
+    /// Cannot be used together with ToolCallBehavior.
+    /// </summary>
+    [JsonIgnore]
+    public new FunctionChoiceBehavior? FunctionChoiceBehavior
+    {
+        get => base.FunctionChoiceBehavior;
+        set
+        {
+            if (value is not null && this.ToolCallBehavior is not null)
+            {
+                throw new InvalidOperationException("ToolCallBehavior and FunctionChoiceBehavior cannot be used together. Please use only one of them.");
+            }
+            base.FunctionChoiceBehavior = value;
+        }
+    }
 }

--- a/dotnet/src/Connectors/Connectors.Onnx/OnnxRuntimeGenAIPromptExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.Onnx/OnnxRuntimeGenAIPromptExecutionSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
@@ -149,4 +149,36 @@ public sealed class OnnxRuntimeGenAIPromptExecutionSettings : PromptExecutionSet
     [JsonPropertyName("do_sample")]
     [JsonConverter(typeof(OptionalBoolJsonConverter))]
     public bool? DoSample { get; set; }
+
+    /// <summary>
+    /// The tool call behavior to use for the ONNX model.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The ONNX model can have its behavior configured to use tools. This can be:
+    /// </para>
+    /// <list type="bullet">
+    /// <item>To disable all tool calling, set the property to null (the default).</item>
+    /// <item>
+    /// To allow the model to request one of any number of functions, set the property to an
+    /// instance returned from <see cref="OnnxToolCallBehavior.EnableFunctions"/>, called with
+    /// a list of the functions available.
+    /// </item>
+    /// <item>
+    /// To allow the model to request one of any of the functions in the supplied <see cref="Kernel"/>,
+    /// set the property to <see cref="OnnxToolCallBehavior.EnableKernelFunctions"/> if the client should simply
+    /// send the information about the functions and not handle the response in any special manner, or
+    /// <see cref="OnnxToolCallBehavior.AutoInvokeKernelFunctions"/> if the client should attempt to automatically
+    /// invoke the function and send the result back to the service.
+    /// </item>
+    /// </list>
+    /// For all options where an instance is provided, auto-invoke behavior may be selected. If the service
+    /// sends a request for a function call, if auto-invoke has been requested, the client will attempt to
+    /// resolve that function from the functions available in the <see cref="Kernel"/>, and if found, rather
+    /// than returning the response back to the caller, it will handle the request automatically, invoking
+    /// the function, and sending back the result. The intermediate messages will be retained in the
+    /// <see cref="ChatHistory"/> if an instance was provided.
+    /// </remarks>
+    [JsonIgnore]
+    public OnnxToolCallBehavior? ToolCallBehavior { get; set; }
 }

--- a/dotnet/src/Connectors/Connectors.Onnx/OnnxServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Onnx/OnnxServiceCollectionExtensions.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
-using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.ChatCompletion;
@@ -18,27 +18,70 @@ namespace Microsoft.SemanticKernel;
 public static class OnnxServiceCollectionExtensions
 {
     /// <summary>
-    /// Add OnnxRuntimeGenAI Chat Completion services to the specified service collection.
+    /// Adds the OnnxRuntimeGenAI Chat Completion services to the specified <see cref="IServiceCollection"/>.
     /// </summary>
-    /// <param name="services">The service collection to add the OnnxRuntimeGenAI Text Generation service to.</param>
-    /// <param name="modelId">The name of the model.</param>
-    /// <param name="modelPath">The generative AI ONNX model path.</param>
-    /// <param name="serviceId">Optional service ID.</param>
-    /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for various aspects of serialization and deserialization required by the service.</param>
-    /// <returns>The updated service collection.</returns>
+    /// <param name="services">The <see cref="IServiceCollection"/> instance to augment.</param>
+    /// <param name="modelPath">The generative AI ONNX model path for the chat completion service.</param>
+    /// <param name="serviceId">A local identifier for the given AI service.</param>
+    /// <param name="modelId">Model Id.</param>
+    /// <param name="loggerFactory">Logger factory.</param>
+    /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for various aspects of serialization, such as function argument deserialization, function result serialization, logging, etc., of the service.</param>
+    /// <param name="providers">Providers</param>
+    /// <returns>The same instance as <paramref name="services"/>.</returns>
     public static IServiceCollection AddOnnxRuntimeGenAIChatCompletion(
         this IServiceCollection services,
-        string modelId,
         string modelPath,
-        string? serviceId = null,
-        JsonSerializerOptions? jsonSerializerOptions = null)
+        string serviceId,
+        string? modelId = null,
+        ILoggerFactory? loggerFactory = null,
+        JsonSerializerOptions? jsonSerializerOptions = null,
+        List<string>? providers = null
+    )
     {
-        services.AddKeyedSingleton<IChatCompletionService>(serviceId, (serviceProvider, _) =>
+        services.AddKeyedSingleton<IChatCompletionService>(serviceId, (_, _) =>
             new OnnxRuntimeGenAIChatCompletionService(
-                modelId,
-                modelPath,
-                loggerFactory: serviceProvider.GetService<ILoggerFactory>(),
-                jsonSerializerOptions));
+                modelPath: modelPath,
+                modelId: modelId,
+                loggerFactory: loggerFactory,
+                jsonSerializerOptions: jsonSerializerOptions,
+                providers: providers
+            )
+        );
+
+        return services;
+    }
+
+
+    /// <summary>\
+    /// Adds the OnnxRuntimeGenAI Chat Completion services with function calling support to the specified <see cref="IServiceCollection"/>.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> instance to augment.</param>
+    /// <param name="modelPath">The generative AI ONNX model path for the chat completion service.</param>
+    /// <param name="serviceId">A local identifier for the given AI service.</param>
+    /// <param name="modelId">Model Id.</param>
+    /// <param name="loggerFactory">Logger factory.</param>
+    /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for various aspects of serialization, such as function argument deserialization, function result serialization, logging, etc., of the service.</param>
+    /// <param name="providers">Providers</param>
+    /// <returns>The same instance as <paramref name="services"/>.</returns>
+    public static IServiceCollection AddOnnxRuntimeGenAIFunctionCallingChatCompletion(
+        this IServiceCollection services,
+        string modelPath,
+        string serviceId,
+        string? modelId = null,
+        ILoggerFactory? loggerFactory = null,
+        JsonSerializerOptions? jsonSerializerOptions = null,
+        List<string>? providers = null
+    )
+    {
+        services.AddKeyedSingleton<IChatCompletionService>(serviceId, (_, _) =>
+            new OnnxRuntimeGenAIFunctionCallingChatCompletionService(
+                modelPath: modelPath,
+                modelId: modelId,
+                loggerFactory: loggerFactory,
+                jsonSerializerOptions: jsonSerializerOptions,
+                providers: providers
+            )
+        );
 
         return services;
     }

--- a/dotnet/src/Connectors/Connectors.Onnx/OnnxToolCallBehavior.cs
+++ b/dotnet/src/Connectors/Connectors.Onnx/OnnxToolCallBehavior.cs
@@ -1,0 +1,211 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text.Json;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace Microsoft.SemanticKernel.Connectors.Onnx;
+
+/// <summary>Represents a behavior for ONNX tool calls.</summary>
+public abstract class OnnxToolCallBehavior
+{
+    /// <summary>
+    /// The default maximum number of tool-call auto-invokes that can be made in a single request.
+    /// </summary>
+    /// <remarks>
+    /// After this number of iterations as part of a single user request is reached, auto-invocation
+    /// will be disabled (e.g. <see cref="AutoInvokeKernelFunctions"/> will behave like <see cref="EnableKernelFunctions"/>).
+    /// This is a safeguard against possible runaway execution if the model routinely re-requests
+    /// the same function over and over. It is currently hardcoded, but in the future it could
+    /// be made configurable by the developer.
+    /// </remarks>
+    private const int DefaultMaximumAutoInvokeAttempts = 128;
+
+    /// <summary>
+    /// Gets an instance that will provide all of the <see cref="Kernel"/>'s plugins' function information.
+    /// Function call requests from the model will be propagated back to the caller.
+    /// </summary>
+    /// <remarks>
+    /// If no <see cref="Kernel"/> is available, no function information will be provided to the model.
+    /// </remarks>
+    public static OnnxToolCallBehavior EnableKernelFunctions { get; } = new KernelFunctions(autoInvoke: false);
+
+    /// <summary>
+    /// Gets an instance that will both provide all of the <see cref="Kernel"/>'s plugins' function information
+    /// to the model and attempt to automatically handle any function call requests.
+    /// </summary>
+    /// <remarks>
+    /// When successful, tool call requests from the model become an implementation detail, with the service
+    /// handling invoking any requested functions and supplying the results back to the model.
+    /// If no <see cref="Kernel"/> is available, no function information will be provided to the model.
+    /// </remarks>
+    public static OnnxToolCallBehavior AutoInvokeKernelFunctions { get; } = new KernelFunctions(autoInvoke: true);
+
+    /// <summary>Gets an instance that will provide the specified list of functions to the model.</summary>
+    /// <param name="functions">The functions that should be made available to the model.</param>
+    /// <param name="autoInvoke">true to attempt to automatically handle function call requests; otherwise, false.</param>
+    /// <returns>
+    /// The <see cref="OnnxToolCallBehavior"/> that may be set into <see cref="OnnxRuntimeGenAIPromptExecutionSettings.ToolCallBehavior"/>
+    /// to indicate that the specified functions should be made available to the model.
+    /// </returns>
+    public static OnnxToolCallBehavior EnableFunctions(IEnumerable<OnnxFunction> functions, bool autoInvoke = false)
+    {
+        Verify.NotNull(functions);
+        return new EnabledFunctions(functions, autoInvoke);
+    }
+
+    /// <summary>Gets an instance that will request the model to use the specified function.</summary>
+    /// <param name="function">The function the model should request to use.</param>
+    /// <param name="autoInvoke">true to attempt to automatically handle function call requests; otherwise, false.</param>
+    /// <returns>
+    /// The <see cref="OnnxToolCallBehavior"/> that may be set into <see cref="OnnxRuntimeGenAIPromptExecutionSettings.ToolCallBehavior"/>
+    /// to indicate that the specified function should be requested by the model.
+    /// </returns>
+    public static OnnxToolCallBehavior RequireFunction(OnnxFunction function, bool autoInvoke = false)
+    {
+        Verify.NotNull(function);
+        return new RequiredFunction(function, autoInvoke);
+    }
+
+    /// <summary>Initializes the instance; prevents external instantiation.</summary>
+    private OnnxToolCallBehavior(bool autoInvoke)
+    {
+        this.MaximumAutoInvokeAttempts = autoInvoke ? DefaultMaximumAutoInvokeAttempts : 0;
+    }
+
+    /// <summary>
+    /// Options to control tool call result serialization behavior.
+    /// </summary>
+    [Obsolete("This property is deprecated in favor of Kernel.SerializerOptions that will be introduced in one of the following releases.")]
+    [ExcludeFromCodeCoverage]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual JsonSerializerOptions? ToolCallResultSerializerOptions { get; set; }
+
+    /// <summary>Gets the maximum number of tool-call auto-invokes that can be made in a single request.</summary>
+    public int MaximumAutoInvokeAttempts { get; private init; }
+
+    /// <summary>Gets whether to automatically invoke functions.</summary>
+    public bool AutoInvoke => this.MaximumAutoInvokeAttempts > 0;
+
+    /// <summary>Gets whether to allow invocation of kernel functions that weren't advertised to the model.</summary>
+    /// <remarks>
+    /// When this property is set to <see langword="true"/>, the model can request to invoke any function
+    /// available in the <see cref="Kernel"/>, regardless of whether it was advertised to the model or not.
+    /// When this property is set to <see langword="false"/>, the model can only request to invoke functions
+    /// that were advertised to the model.
+    /// </remarks>
+    public virtual bool AllowAnyRequestedKernelFunction { get; internal set; }
+
+    /// <summary>Gets the options to use when processing function calls.</summary>
+    public abstract FunctionChoiceBehaviorOptions? Options { get; }
+
+    /// <summary>Configures the request with any tool information this <see cref="OnnxToolCallBehavior"/> provides.</summary>
+    /// <param name="kernel">The <see cref="Kernel"/> to use for function calling.</param>
+    /// <param name="chatHistory">The chat history to use for function calling.</param>
+    /// <param name="requestIndex">The request index.</param>
+    /// <returns>The tools configuration for the request.</returns>
+    internal abstract OnnxToolCallingConfig ConfigureRequest(Kernel? kernel, ChatHistory chatHistory, int requestIndex);
+
+    /// <summary>
+    /// Clones the current instance.
+    /// </summary>
+    /// <returns>A new instance that is a copy of the current instance.</returns>
+    internal OnnxToolCallBehavior Clone()
+    {
+        return (OnnxToolCallBehavior)this.MemberwiseClone();
+    }
+
+    /// <summary>
+    /// Represents a <see cref="OnnxToolCallBehavior"/> that will provide to the model all available functions from a
+    /// <see cref="Kernel"/>.
+    /// </summary>
+    internal sealed class KernelFunctions : OnnxToolCallBehavior
+    {
+        /// <summary>Initializes the instance.</summary>
+        /// <param name="autoInvoke">true to attempt to automatically handle function call requests; otherwise, false.</param>
+        public KernelFunctions(bool autoInvoke) : base(autoInvoke)
+        {
+            this.AllowAnyRequestedKernelFunction = true;
+        }
+
+        /// <inheritdoc/>
+        public override FunctionChoiceBehaviorOptions? Options { get; } = new();
+
+        /// <inheritdoc/>
+        internal override OnnxToolCallingConfig ConfigureRequest(Kernel? kernel, ChatHistory chatHistory, int requestIndex)
+        {
+            return new OnnxToolCallingConfig(
+                Tools: GetKernelFunctions(kernel),
+                AutoInvoke: this.AutoInvoke,
+                AllowAnyRequestedKernelFunction: this.AllowAnyRequestedKernelFunction,
+                Options: this.Options);
+        }
+
+        /// <summary>Gets the functions from the kernel.</summary>
+        private static IList<OnnxFunction>? GetKernelFunctions(Kernel? kernel)
+        {
+            if (kernel is null)
+            {
+                return null;
+            }
+
+            return kernel.Plugins.GetFunctionsMetadata().Select(f => f.ToOnnxFunction()).ToList();
+        }
+    }
+
+    /// <summary>
+    /// Represents a <see cref="OnnxToolCallBehavior"/> that provides a specified list of functions to the model.
+    /// </summary>
+    internal sealed class EnabledFunctions(IEnumerable<OnnxFunction> functions, bool autoInvoke) : OnnxToolCallBehavior(autoInvoke)
+    {
+        /// <inheritdoc/>
+        public override FunctionChoiceBehaviorOptions? Options { get; } = new();
+
+        /// <inheritdoc/>
+        internal override OnnxToolCallingConfig ConfigureRequest(Kernel? kernel, ChatHistory chatHistory, int requestIndex)
+        {
+            return new OnnxToolCallingConfig(
+                Tools: functions.ToList(),
+                AutoInvoke: this.AutoInvoke,
+                AllowAnyRequestedKernelFunction: this.AllowAnyRequestedKernelFunction,
+                Options: this.Options);
+        }
+    }
+
+    /// <summary>
+    /// Represents a <see cref="OnnxToolCallBehavior"/> that requests a specific function to be invoked.
+    /// </summary>
+    internal sealed class RequiredFunction(OnnxFunction function, bool autoInvoke) : OnnxToolCallBehavior(autoInvoke)
+    {
+        /// <inheritdoc/>
+        public override FunctionChoiceBehaviorOptions? Options { get; } = new();
+
+        /// <inheritdoc/>
+        internal override OnnxToolCallingConfig ConfigureRequest(Kernel? kernel, ChatHistory chatHistory, int requestIndex)
+        {
+            return new OnnxToolCallingConfig(
+                Tools: [function],
+                AutoInvoke: this.AutoInvoke,
+                AllowAnyRequestedKernelFunction: this.AllowAnyRequestedKernelFunction,
+                Options: this.Options);
+        }
+    }
+}
+
+/// <summary>
+/// Configuration for ONNX tool calling.
+/// </summary>
+/// <param name="Tools">The list of tools available to the model.</param>
+/// <param name="AutoInvoke">Whether to automatically invoke functions.</param>
+/// <param name="AllowAnyRequestedKernelFunction">Whether to allow invocation of kernel functions that weren't advertised to the model.</param>
+/// <param name="Options">The options to use when processing function calls.</param>
+internal record OnnxToolCallingConfig(
+    IList<OnnxFunction>? Tools,
+    bool AutoInvoke,
+    bool AllowAnyRequestedKernelFunction,
+    FunctionChoiceBehaviorOptions? Options);

--- a/dotnet/src/Connectors/Connectors.Onnx/README.md
+++ b/dotnet/src/Connectors/Connectors.Onnx/README.md
@@ -88,6 +88,26 @@ The ONNX connector implements function calling by:
 3. **Response Parsing**: The model's response is parsed for function call requests
 4. **Function Execution**: Functions are executed and results are fed back to the model
 
+### Enhanced Parsing
+
+The connector now supports multiple parsing strategies:
+
+- **JSON Code Blocks**: Extracts function calls from ```json ... ``` blocks
+- **Inline Code**: Extracts function calls from `{...}` inline code blocks
+- **Raw JSON**: Parses function calls from direct JSON responses
+- **Regex Fallback**: Uses regex patterns for non-standard formats
+
+### Auto-Invoke Fallback
+
+When the standard function calling pipeline fails (common with some ONNX models like Phi-4), the connector automatically falls back to manual function invocation:
+
+1. **Detection**: Identifies function calls in the model's response
+2. **Validation**: Verifies the function exists and is allowed
+3. **Execution**: Manually invokes the function through the kernel
+4. **Result**: Returns the function result instead of the JSON call
+
+This ensures compatibility with models that generate function calls but don't work well with the standard auto-invoke pipeline.
+
 ### Function Call Format
 
 The model is instructed to make function calls in the following JSON format:
@@ -150,10 +170,27 @@ For function calling to work effectively, the ONNX model should:
 - Be able to generate structured JSON output
 - Have been fine-tuned or trained to understand function calling patterns
 
-Popular models that work well include:
-- Phi-3 Mini
+### Model Compatibility
+
+**Models with Full Auto-Invoke Support:**
 - Llama 2/3 Chat variants
-- Other instruction-tuned models
+- Mistral variants
+- Some Phi-3 variants
+
+**Models with Fallback Support (Manual Invocation):**
+- Phi-4 Multimodal Instruct ONNX
+- Other models that generate function calls but don't work with standard auto-invoke
+
+The connector automatically detects which approach works best for each model and uses the appropriate method.
+
+### Troubleshooting
+
+If function calling isn't working:
+
+1. **Check Logs**: Enable debug logging to see parsing attempts
+2. **Verify Model**: Ensure the model supports instruction following
+3. **Test Parsing**: Try different function call formats
+4. **Fallback**: The manual fallback should work even if auto-invoke fails
 
 ## Configuration
 

--- a/dotnet/src/Connectors/Connectors.Onnx/README.md
+++ b/dotnet/src/Connectors/Connectors.Onnx/README.md
@@ -1,0 +1,199 @@
+# ONNX Connector for Semantic Kernel
+
+This connector provides support for using ONNX models with Semantic Kernel, including function calling capabilities.
+
+## Features
+
+### Basic Chat Completion
+- Basic chat completion using ONNX Runtime GenAI
+- Streaming and non-streaming responses
+- Customizable execution settings
+
+### Function Calling (New)
+- **Auto-invocation**: Automatically invoke functions when the model requests them
+- **Manual invocation**: Get function call requests and handle them manually
+- **Specific function sets**: Configure which functions are available to the model
+- **Kernel function integration**: Seamlessly integrate with Semantic Kernel plugins
+
+## Usage
+
+### Basic Setup
+
+```csharp
+var builder = Kernel.CreateBuilder()
+    .AddOnnxRuntimeGenAIChatCompletion("phi-3-mini-4k-instruct", "path/to/model");
+
+Kernel kernel = builder.Build();
+```
+
+### Function Calling Setup
+
+```csharp
+var builder = Kernel.CreateBuilder()
+    .AddOnnxRuntimeGenAIFunctionCallingChatCompletion("phi-3-mini-4k-instruct", "path/to/model");
+
+// Add plugins
+builder.Plugins.AddFromType<TimePlugin>();
+builder.Plugins.AddFromType<MathPlugin>();
+
+Kernel kernel = builder.Build();
+```
+
+### Auto-Invocation
+
+```csharp
+OnnxRuntimeGenAIPromptExecutionSettings settings = new()
+{
+    ToolCallBehavior = OnnxToolCallBehavior.AutoInvokeKernelFunctions
+};
+
+var result = await kernel.InvokePromptAsync("What time is it?", new(settings));
+```
+
+### Manual Invocation
+
+```csharp
+OnnxRuntimeGenAIPromptExecutionSettings settings = new()
+{
+    ToolCallBehavior = OnnxToolCallBehavior.EnableKernelFunctions
+};
+
+var result = await kernel.InvokePromptAsync("What time is it?", new(settings));
+// Handle function calls manually from the result
+```
+
+### Specific Functions
+
+```csharp
+var onnxFunctions = new[]
+{
+    myFunction.Metadata.ToOnnxFunction(),
+    anotherFunction.Metadata.ToOnnxFunction()
+};
+
+OnnxRuntimeGenAIPromptExecutionSettings settings = new()
+{
+    ToolCallBehavior = OnnxToolCallBehavior.EnableFunctions(onnxFunctions, autoInvoke: true)
+};
+
+var result = await kernel.InvokePromptAsync("Use my specific functions", new(settings));
+```
+
+## Function Calling Implementation
+
+The ONNX connector implements function calling by:
+
+1. **Function Registration**: Functions are registered with their metadata and JSON schema
+2. **Prompt Enhancement**: Function definitions are added to the system prompt
+3. **Response Parsing**: The model's response is parsed for function call requests
+4. **Function Execution**: Functions are executed and results are fed back to the model
+
+### Function Call Format
+
+The model is instructed to make function calls in the following JSON format:
+
+```json
+{
+  "function_call": {
+    "name": "function_name",
+    "arguments": {
+      "param1": "value1",
+      "param2": "value2"
+    }
+  }
+}
+```
+
+### Function Definition Schema
+
+Functions are provided to the model using JSON schema format:
+
+```json
+{
+  "name": "get_current_time",
+  "description": "Get the current time in UTC",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "timezone": {
+        "type": "string",
+        "description": "The timezone ID"
+      }
+    },
+    "required": ["timezone"]
+  }
+}
+```
+
+## Classes
+
+### OnnxToolCallBehavior
+- `EnableKernelFunctions`: Enable all kernel functions without auto-invocation
+- `AutoInvokeKernelFunctions`: Enable all kernel functions with auto-invocation
+- `EnableFunctions(functions, autoInvoke)`: Enable specific functions
+- `RequireFunction(function, autoInvoke)`: Require a specific function
+
+### OnnxFunction
+- Represents a function that can be called by the ONNX model
+- Provides JSON schema generation for function definitions
+- Handles function call parsing and result formatting
+
+### OnnxRuntimeGenAIFunctionCallingChatCompletionService
+- Extended chat completion service with function calling support
+- Integrates with Semantic Kernel's function calling infrastructure
+- Handles both streaming and non-streaming scenarios
+
+## Model Requirements
+
+For function calling to work effectively, the ONNX model should:
+- Support instruction following
+- Be able to generate structured JSON output
+- Have been fine-tuned or trained to understand function calling patterns
+
+Popular models that work well include:
+- Phi-3 Mini
+- Llama 2/3 Chat variants
+- Other instruction-tuned models
+
+## Configuration
+
+### Execution Settings
+
+```csharp
+OnnxRuntimeGenAIPromptExecutionSettings settings = new()
+{
+    ToolCallBehavior = OnnxToolCallBehavior.AutoInvokeKernelFunctions,
+    Temperature = 0.7f,
+    TopP = 0.9f,
+    MaxTokens = 1000,
+    // ... other ONNX-specific settings
+};
+```
+
+### Function Call Options
+
+```csharp
+var options = new FunctionChoiceBehaviorOptions
+{
+    AllowConcurrentInvocation = true,
+    AllowAnyRequestedKernelFunction = false
+};
+```
+
+## Error Handling
+
+The connector handles various error scenarios:
+- JSON parsing errors when interpreting function calls
+- Function not found errors
+- Function execution errors
+- Model timeout or generation errors
+
+## Performance Considerations
+
+- Function definitions are included in the system prompt, which increases token usage
+- Auto-invocation requires multiple model calls for complex function chains
+- Consider using streaming for better user experience with function calls
+
+## Examples
+
+See the `Onnx_FunctionCalling.cs` sample for comprehensive examples of all function calling scenarios.


### PR DESCRIPTION
### Motivation and Context

This change introduces function calling support for the ONNX connector in .NET. It enables instruction-tuned ONNX models (e.g., Phi-3, Llama) to interact with and invoke .NET functions defined within Semantic Kernel, expanding the capabilities of ONNX models within the SK ecosystem.

### Description

This PR implements comprehensive function calling support for the ONNX connector in .NET.

Key additions include:
- **`OnnxToolCallBehavior`**: A new class to manage various function calling modes, including auto-invocation, manual invocation, and enabling specific sets of functions.
- **`OnnxFunction`**: A class representing functions that can be called by ONNX models, handling JSON schema conversion for function definitions and parsing function call requests from model responses.
- **`OnnxRuntimeGenAIFunctionCallingChatCompletionService`**: A new chat completion service that integrates with Semantic Kernel's `FunctionCallsProcessor` to facilitate the function calling workflow.
- **Extensions**: `OnnxRuntimeGenAIPromptExecutionSettings` is enhanced with a `ToolCallBehavior` property, and `OnnxKernelBuilderExtensions` gains a new method (`AddOnnxRuntimeGenAIFunctionCallingChatCompletion`) for easy service registration.

The implementation works by injecting function definitions into the system prompt, parsing model responses for function call requests (supporting both JSON and regex patterns), and executing the functions through the standard Semantic Kernel pipeline. This provides a flexible and robust mechanism for ONNX models to leverage external tools.

Comprehensive unit tests and usage examples are included to demonstrate the new functionality.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile: